### PR TITLE
change margin to padding on project title modal

### DIFF
--- a/src/styles/_new-project-title.scss
+++ b/src/styles/_new-project-title.scss
@@ -1,7 +1,8 @@
 $block-class:'new-project-title';
+
 @at-root {
     .#{$block-class} {
-        margin: 4em 2em 4em 2em;
+        padding: 3em 2em;
 
         &__name {
             width: 100%;


### PR DESCRIPTION
#### What's this PR do?
Fix the incorrect background color on the new project title modal by using padding instead of margin

#### Related JIRA tickets:
[INBA-154](https://jira.amida-tech.com/browse/INBA-154)

#### How should this be manually tested?
Load http://localhost:3000/create-new-project
Check that the background color is not white at the top of the modal

#### Any background context you want to provide?
The text of this PR is several orders of magnitude longer than the PR diff

#### Screenshots (if appropriate):
