### PR TITLE
INBA-185 Unassigned filters

### DIFF
--- a/src/views/ProjectManagement/components/Workflow/FilteredRow.js
+++ b/src/views/ProjectManagement/components/Workflow/FilteredRow.js
@@ -19,15 +19,17 @@ class FilteredRow extends Component {
         case 'unassigned':
             return taskData.userId;
         case 'late':
-            return !(TaskStatus.dueDateInPast(taskData, this.props.stages) &&
-                        !TaskStatus.responsesComplete(taskData, this.props.surveySize));
+            return !taskData.userId ||
+                (!(TaskStatus.dueDateInPast(taskData, this.props.stages) &&
+                !TaskStatus.responsesComplete(taskData, this.props.surveySize)));
         case 'inprogress':
-            return !(TaskStatus.responsesExist(taskData) &&
-                        !TaskStatus.responsesComplete(taskData, this.props.surveySize));
+            return !taskData.userId ||
+                (!(TaskStatus.responsesExist(taskData) &&
+                !TaskStatus.responsesComplete(taskData, this.props.surveySize)));
         case 'notstarted':
-            return TaskStatus.responsesExist(taskData);
+            return !taskData.userId || TaskStatus.responsesExist(taskData);
         case 'flagged':
-            return !TaskStatus.responsesFlagged(taskData);
+            return !taskData.userId || !TaskStatus.responsesFlagged(taskData);
         default:
             return false;
         }


### PR DESCRIPTION
#### What's this PR do?
Fix filters so that any unassigned task is filtered by all filters except `unassigned`

#### Related JIRA tickets:
[INBA-185](https://jira.amida-tech.com/browse/INBA-185)

#### How should this be manually tested?
1. Load http://localhost:3000/project/101
2. Test all filters and ensure that unassigned tasks are filtered except when there is no filter applied, or when the `unassigned` filter is applied. Check that entire rows are omitted when appropriate.

#### Any background context you want to provide?
I put the additional logic directly in `taskIsFilteredOut` because
1. That asserts that the `TaskStatus` functions are only valid for tasks (as opposed to the absence of a task)
2. `_taskLookup` in `FilteredRow.js` is what defines the object passed to `taskIsFilteredOut` for unassigned tasks

#### Screenshots (if appropriate):
