### PR TITLE
INBA-187 Prevent date input jumping

### DIFF
--- a/src/styles/_task-details.scss
+++ b/src/styles/_task-details.scss
@@ -67,7 +67,8 @@ $block-class:'task-details';
     }
 }
 
-.grommetux-date-time__input {
+.grommetux-date-time__input,
+.grommetux-date-time__input:focus {
     padding: 0;
     border: none;
     font-size: 16px;


### PR DESCRIPTION
#### What's this PR do?
Apply 0 padding and border when date input is focused in addition to not focused to prevent the elements from moving on focus

#### Related JIRA tickets:
[INBA-187](https://jira.amida-tech.com/browse/INBA-187)

#### How should this be manually tested?
1. Load a task review page (http://localhost:3000/task-review/101/13)
2. Check that giving focus to the text input of the date component does not cause the elements to move

#### Any background context you want to provide?
#### Screenshots (if appropriate):
