### PR TITLE
INBA-88 omit due date text when late or done

### DIFF
--- a/src/views/ProjectManagement/components/Workflow/StageSlot.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSlot.js
@@ -54,13 +54,13 @@ class StageSlot extends Component {
 
     displayDueTime() {
         if (this.state.done) {
-            return (this.props.vocab.DONE);
+            return '';
         } else if (this.state.diff <= 0) {
-            return (this.props.vocab.LATE);
+            return '';
         } else if (this.state.diff === 1) {
-            return (this.props.vocab.DUE_TOMORROW);
+            return this.props.vocab.DUE_TOMORROW;
         } else if (this.state.diff > 1) {
-            return (this.props.vocab.DUE_IN + this.state.diff + this.props.vocab.DAYS);
+            return this.props.vocab.DUE_IN + this.state.diff + this.props.vocab.DAYS;
         }
         return '';
     }
@@ -102,7 +102,7 @@ class StageSlot extends Component {
                     </div>
                     <div className='stage-slot__due-row'>
                         <div>
-                            {this.displayDueTime()} &nbsp;
+                            {this.displayDueTime()}
                             <span
                                 className={labelDisplay ? `stage-slot__label stage-slot__label${labelDisplay.mod}` : ''} >
                                 {labelDisplay.term}


### PR DESCRIPTION
#### What's this PR do?
Omit the left-side Late and Done text in stage slots

#### Related JIRA tickets:
[INBA-88](https://jira.amida-tech.com/browse/INBA-88)

#### How should this be manually tested?
Load http://localhost:3000/101 and check that tasks that are late or done do not have duplicate text on the left side stating so.

#### Any background context you want to provide?
The Jira ticket also required adding a not-started label, which was added in an earlier ticket, and an in-progress label which has been removed from the design

#### Screenshots (if appropriate):
