### PR TITLE
INBA-135 rename profile user group tab class to avoid name conflict

### DIFF
--- a/src/views/ProjectManagement/components/Users/PMUsersTab/UserProfile/ProfileUserGroupsTab.js
+++ b/src/views/ProjectManagement/components/Users/PMUsersTab/UserProfile/ProfileUserGroupsTab.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import UserGroupList from '../../../../../../common/components/UserGroupList';
 
-class UserGroupsTab extends Component {
+class ProfileUserGroupsTab extends Component {
     render() {
         const groups = this.props.project.userGroups
             .filter(group => group.users.includes(this.props.userId));
@@ -13,10 +13,10 @@ class UserGroupsTab extends Component {
     }
 }
 
-UserGroupsTab.propTypes = {
+ProfileUserGroupsTab.propTypes = {
     project: PropTypes.object.isRequired,
     users: PropTypes.arrayOf(PropTypes.object).isRequired,
     vocab: PropTypes.object.isRequired,
 };
 
-export default UserGroupsTab;
+export default ProfileUserGroupsTab;

--- a/src/views/ProjectManagement/components/Users/PMUsersTab/UserProfile/UserProfileForm.js
+++ b/src/views/ProjectManagement/components/Users/PMUsersTab/UserProfile/UserProfileForm.js
@@ -4,7 +4,7 @@ import { reduxForm, FormSection } from 'redux-form';
 import { Tabs, Tab } from 'grommet';
 import UserNameInput from './UserNameInput';
 import AccountTab from './AccountTab';
-import UserGroupsTab from './UserGroupsTab';
+import ProfileUserGroupsTab from './ProfileUserGroupsTab';
 import TasksTab from './TasksTab';
 import PreferenceTab from './PreferenceTab';
 
@@ -27,7 +27,7 @@ class UserProfileForm extends Component {
                         </FormSection>
                     </Tab>
                     <Tab title={this.props.vocab.PROJECT.USER_GROUPS}>
-                        <UserGroupsTab {...this.props} />
+                        <ProfileUserGroupsTab {...this.props} />
                     </Tab>
                     <Tab title={this.props.vocab.PROJECT.TASKS}>
                         <TasksTab {...this.props} />


### PR DESCRIPTION
#### What's this PR do?
Resolve a duplicate component name

#### Related JIRA tickets:
[INBA-135](https://jira.amida-tech.com/browse/INBA-135)

#### How should this be manually tested?
Load http://localhost:3000/project/101 and check that it runs, and in particular that the user groups tab in the user profile modal (open by click on a name in the user list on the Users tab) works.
Check that there are no duplicate class names (`grep -hr "class\s.*\sextends\sComponent" ./src | uniq -d`)

#### Any background context you want to provide?
#### Screenshots (if appropriate):
