### PR TITLE
INBA-203 enforce unique subject list entries in reducers

### DIFF
--- a/src/common/reducers/projectReducer.js
+++ b/src/common/reducers/projectReducer.js
@@ -64,7 +64,9 @@ export const ProjectReducer = (state = initialState, action) => {
             status: { $set: action.status },
         } });
     case type.ADD_SUBJECT:
-        return update(state, { [projectIndex]: {
+        return state[projectIndex].subjects.includes(action.subject) ?
+        state :
+        update(state, { [projectIndex]: {
             subjects: { $push: [action.subject] },
             lastUpdated: { $set: new Date().toISOString() },
         } });

--- a/src/views/CreateProjectWizard/reducer.js
+++ b/src/views/CreateProjectWizard/reducer.js
@@ -1,4 +1,5 @@
 import update from 'immutability-helper';
+import _ from 'lodash';
 import * as type from './actionTypes';
 
 const initialState = {
@@ -45,7 +46,7 @@ export default (state = initialState, action) => {
         return update(state, { ui: { projectTitle: { show: { $set: false } } } });
     case type.ADD_SUBJECTS_TO_WIZARD:
         return update(state, { project:
-            { subjects: { $set: [...(state.project.subjects || []), ...action.subjects] } } });
+            { subjects: { $set: _.union(state.project.subjects, action.subjects) } } });
     case type.DELETE_SUBJECT_FROM_WIZARD:
         return update(state, { project: { subjects:
             { $splice: [[state.project.subjects.indexOf(action.subject), 1]] } } });


### PR DESCRIPTION
#### What's this PR do?
Check for duplicates before adding subjects to existing projects and project wizard

#### Related JIRA tickets:
[INBA-203](https://jira.amida-tech.com/browse/INBA-203)

#### How should this be manually tested?
1. Load http://localhost:3000/project/101
2. Try to add a duplicate subject from the button on the workflow tab and the subjects tab, and check that it doesn't
3. Try to add duplicate subjects in the Add Subjects tab of the project create wizard and check that it doesn't

#### Any background context you want to provide?
#### Screenshots (if appropriate):
