### PR TITLE
INBA-202 prevent adding duplicate users to wizard project

### DIFF
--- a/src/views/CreateProjectWizard/reducer.js
+++ b/src/views/CreateProjectWizard/reducer.js
@@ -50,7 +50,9 @@ export default (state = initialState, action) => {
         return update(state, { project: { subjects:
             { $splice: [[state.project.subjects.indexOf(action.subject), 1]] } } });
     case type.ADD_USER_TO_WIZARD:
-        return update(state, { project: { users: { $push: [action.user.id] } } });
+        return state.project.users.includes(action.user.id) ?
+        state :
+        update(state, { project: { users: { $push: [action.user.id] } } });
     case type.REMOVE_USER_FROM_WIZARD:
         return update(state, { project: { users:
             { $splice: [[state.project.users.indexOf(action.userId), 1]] } } });


### PR DESCRIPTION
#### What's this PR do?
Prevent the user from adding the same user to a project (in the creation wizard) twice.
NOTE: we don't currently have a way to add an existing user to an existing project

#### Related JIRA tickets:
[INBA-202](https://jira.amida-tech.com/browse/INBA-202)

#### How should this be manually tested?
Load the project creation wizard http://localhost:3000/create-new-project
Get to the Add Users step
Attempt to add the same user twice, and ensure it doesn't let you

#### Any background context you want to provide?
#### Screenshots (if appropriate):
