### PR TITLE
INBA-274 Fix SubNavEntry selected prop type

### DIFF
--- a/src/views/ProjectManagement/components/SubNav/SubNavEntry.js
+++ b/src/views/ProjectManagement/components/SubNav/SubNavEntry.js
@@ -17,7 +17,7 @@ class SubNavEntry extends Component {
 SubNavEntry.propTypes = {
     onClick: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
-    selected: PropTypes.string,
+    selected: PropTypes.bool,
     first: PropTypes.bool,
 };
 


### PR DESCRIPTION
#### What's this PR do?
Set the prop type of `selected` on SubNavEntry to bool.

#### Related JIRA tickets:
[INBA-274](https://jira.amida-tech.com/browse/INBA-274)

#### How should this be manually tested?
Load http://localhost:3000/project/101 and check that no proptype error is logged in the console, and that the subnav works

#### Any background context you want to provide?
#### Screenshots (if appropriate):
