### PR TITLE
INBA-275 Prop Type SubNavEntry

### DIFF
--- a/src/views/ProjectManagement/components/SubNav/SubNavEntry.js
+++ b/src/views/ProjectManagement/components/SubNav/SubNavEntry.js
@@ -17,7 +17,7 @@ class SubNavEntry extends Component {
 SubNavEntry.propTypes = {
     onClick: PropTypes.func.isRequired,
     label: PropTypes.string.isRequired,
-    selected: PropTypes.string,
+    selected: PropTypes.bool,
     first: PropTypes.bool,
 };
 


### PR DESCRIPTION
#### What's this PR do?
Have a messed up propType check. In SubNav, we check that selected is a string. In SubNavEntry, a bool. Fixed it, opened to renaming the prop in SNE if anyone cares. 

#### Related JIRA tickets:
INBA-263 was the cause. 

#### How should this be manually tested?
#### Any background context you want to provide?
#### Screenshots (if appropriate):
