### PR TITLE
INBA-363 / ProjectUserGroups assignment

### DIFF
--- a/src/common/actions/projectActions.js
+++ b/src/common/actions/projectActions.js
@@ -150,6 +150,7 @@ export function addUserGroup(groupData, projectId, organizationId, errorMessages
         organizationId,
         langId: 1,
         users: groupData.users,
+        projectId,
     };
     return (dispatch) => {
         apiService.projects.postGroup(


### PR DESCRIPTION
#### What's this PR do?
When you create a new user group, it automatically attaches that group to the Project associated to it. 

#### Related JIRA tickets:
None, but there is a matching ticket in greyscale.

#### How should this be manually tested?
Load up the front and back end, create a project or use an existing project. As you add user Groups, they should populate ProjectUserGroups.

#### Any background context you want to provide?
#### Screenshots (if appropriate):
