### PR TITLE
Changed logic as not to show flag counts when less than 1.

### DIFF
--- a/src/common/components/Dashboard/FlagCount.js
+++ b/src/common/components/Dashboard/FlagCount.js
@@ -9,9 +9,11 @@ class FlagCount extends Component {
             <div className='flag-count'>
                 <IonIcon icon='ion-ios-flag'
                     className='flag-count__icon'/>
-                <div className='flag-count__value'>
-                    {this.props.value}
-                </div>
+                    {this.props.value > 0 &&
+                        <div className='flag-count__value'>
+                            {this.props.value}
+                        </div>
+                    }
             </div>
         );
     }


### PR DESCRIPTION
#### What's this PR do?
Changed logic so flags on the project and tasks landing pages won't show the circle with the number when there are zero flags. Will discuss how to test tomorrow. 

#### Related JIRA tickets:
#### How should this be manually tested?
#### Any background context you want to provide?
#### Screenshots (if appropriate):
