### PR TITLE
added a tooltip to task option hover

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -111,7 +111,9 @@
             "DUE_IN": "Due in ",
             "DAYS": " Days",
             "DUE_TOMORROW": "Due Tomorrow",
-            "MORE_OPTIONS": "More Options"
+            "MORE_OPTIONS": "More Options",
+            "TASK_OPTIONS": "Task Options"
+
         },
         "OPTIONS_MODAL": {
             "TITLE": "Task Options",

--- a/src/views/ProjectManagement/components/Workflow/StageSlot.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSlot.js
@@ -88,7 +88,7 @@ class StageSlot extends Component {
                             <span>{renderName(this.props.user)}</span>
                         </Link>
                         <button className='stage-slot__masked-button stage-slot__right-icon'
-                            title='Task Options'
+                            title= {this.props.vocab.TASK_OPTIONS}
                             onClick={this.handleTaskOptions}>
                             <IonIcon icon='ion-ios-more'/>
                         </button>


### PR DESCRIPTION
#### What's this PR do?
adds a tooltip to the task option hover
#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-358?filter=-1
#### How should this be manually tested?
1. http://localhost:3000/project
2. select project Lacey test
3. click workflow tab
4. hover over elipses on a task
5. The tooltip should say task options
#### Any background context you want to provide? 
#### Screenshots (if appropriate):
