### PR TITLE
manually inject process.env with webpack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.github

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const Dotenv = require('dotenv-webpack');
+const webpack = require('webpack');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
@@ -70,6 +70,14 @@ module.exports = {
     plugins: [
         HtmlWebpackPluginConfig,
         StyleLintPluginConfig,
-        new Dotenv(),
+        new webpack.DefinePlugin({
+            'process.env': {
+                'API_HTTP_URL': JSON.stringify(process.env.API_HTTP_URL),
+                'API_HTTPS_URL': JSON.stringify(process.env.API_HTTPS_URL),
+                'AUTH_API_HTTPS_URL': JSON.stringify(process.env.AUTH_API_HTTPS_URL),
+                'AUTH_API_HTTP_URL': JSON.stringify(process.env.AUTH_API_HTTP_URL),
+                'NODE_ENV': JSON.stringify(process.env.NODE_ENV),
+            }
+        }),
     ],
 };


### PR DESCRIPTION
#### What's this PR do?
Allows process.env to be access from client code running in Docker

#### How should this be manually tested?
Run the client via Docker and make sure it can connect to API endpoints set via `docker run -e "ENV_VAR=var"`
