### PR TITLE
Feature/INBA-125 Implement preference tab of user profile modal

### DIFF
--- a/src/common/reducers/userReducer.js
+++ b/src/common/reducers/userReducer.js
@@ -5,9 +5,9 @@ import { LOG_OUT } from '../actionTypes/navActionTypes';
 
 export const constants = {
     notifications: {
-        OFF: 'OFF',
-        INTERNAL: 'INTERNAL',
-        EMAIL: 'EMAIL',
+        OFF: 0,
+        INTERNAL: 1,
+        EMAIL: 2,
     },
 
     status: {

--- a/src/views/UserProfile/components/PreferenceTab.js
+++ b/src/views/UserProfile/components/PreferenceTab.js
@@ -12,7 +12,8 @@ class PreferenceTab extends Component {
                     {this.props.vocab.USER.NOTIFY_LEVEL}
                     <Field className='preference-tab__input-select'
                         component='select'
-                        name='notifications'>
+                        name='notifyLevel'
+                        normalize={value => parseInt(value, 0)}>
                         <option className='preference-tab__input-option'
                             value={constants.notifications.OFF}>
                             {this.props.vocab.USER.NOTIFY_OFF}
@@ -31,7 +32,11 @@ class PreferenceTab extends Component {
                     {this.props.vocab.USER.STATUS}
                     <Field className='preference-tab__input-select'
                         component='select'
-                        name='status' >
+                        name='isActive'
+                        normalize={value => value === constants.status.ACTIVE}
+                        format={value => (value ?
+                            constants.status.ACTIVE :
+                            constants.status.INACTIVE)}>
                         <option className='preference-tab__input-option'
                             value={constants.status.ACTIVE}>
                             {this.props.vocab.USER.ACTIVE}

--- a/src/views/UserProfile/components/UserProfile.js
+++ b/src/views/UserProfile/components/UserProfile.js
@@ -19,15 +19,17 @@ class UserProfile extends Component {
                     initialValues={this.props.initialValues}
                     onSubmit={ (values) => {
                         this.props.onSave();
-                        this.props.onUpdateUser(this.props.userId, {
-                            firstName: values.name.firstName,
-                            lastName: values.name.lastName,
-                            email: values.account.email,
-                            title: values.account.title,
-                            notifyLevel: values.preferences.notifications,
-                            status: values.preferences.status,
-                            notes: values.preferences.notes,
-                        }, this.props.vocab.ERROR);
+                        this.props.onUpdateUser(this.props.userId,
+                            Object.assign({}, this.props.user, {
+                                firstName: values.name.firstName,
+                                lastName: values.name.lastName,
+                                email: values.account.email,
+                                title: values.account.title,
+                                notifyLevel: values.preferences.notifyLevel,
+                                isActive: values.preferences.isActive,
+                                notes: values.preferences.notes,
+                            }),
+                            this.props.vocab.ERROR);
                     }}/>
                 </Modal>
         );

--- a/src/views/UserProfile/components/index.js
+++ b/src/views/UserProfile/components/index.js
@@ -55,8 +55,8 @@ const mapStateToProps = (state, ownProps) => {
                 title: user.title,
             },
             preferences: {
-                notifications: user.notifications,
-                status: user.status,
+                notifyLevel: user.notifyLevel,
+                isActive: user.isActive,
                 notes: user.notes,
             },
         },


### PR DESCRIPTION
#### What's this PR do?
Rename the user profile modal fields for `isActive` and `notifyLevel` values on the backend.

#### Related JIRA tickets:
[INBA-125](https://jira.amida-tech.com/browse/INBA-125)

#### How should this be manually tested?
1. Log in as admin
1. Go to a project
1. Go to the users tab
1. Click on a user name to bring up the user profile
1. Change the notification level and status
1. Save the changes
1. Check that the changes are written to the backend and repopulate correctly when reopening the user profile

#### Any background context you want to provide?
#### Screenshots (if appropriate):
