### PR TITLE
Changes that fix display of Task Options Modal.

### DIFF
--- a/src/views/ProjectManagement/components/Modals/TaskOptions/index.js
+++ b/src/views/ProjectManagement/components/Modals/TaskOptions/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { submit } from 'redux-form';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { find } from 'lodash';
 
 import { renderName } from '../../../../../utils/User';
 import Modal from '../../../../../common/components/Modal';
@@ -10,8 +10,8 @@ import TaskOptionsForm from './TaskOptionsForm';
 
 class TaskOptionsModal extends Component {
     render() {
-        const currentUser = _.find(this.props.users, user =>
-            user.id === this.props.task.userId);
+        const currentUser = find(this.props.users, user =>
+            user.id === this.props.task.userIds[0]);
         const userOptions = this.props.users.map(user => (
                 user === currentUser ?
                 { value: user, label: renderName(user) + this.props.vocab._CURRENTLY_ASSIGNED } :
@@ -41,18 +41,18 @@ class TaskOptionsModal extends Component {
                     initialValues={initialValues}
                     onSubmit={ (values) => {
                         if (values.choice === 'reassign') {
-                            this.props.taskActions.reassignTask(
+                            this.props.actions.reassignTask(
                                 values.reassignUser.value.id,
                                 this.props.task.id,
                                 this.props.projectId,
                             );
                         } else if (values.choice === 'force') {
-                            this.props.discussActions.forceTaskCompletion(
+                            this.props.actions.forceTaskCompletion(
                                 this.props.task.id,
                             );
                         }
                         if (values.notify === true) {
-                            this.props.userActions.notifyUser(
+                            this.props.actions.notifyUser(
                                 this.props.task.userId,
                                 values.message,
                                 this.props.profile.id,
@@ -73,9 +73,7 @@ TaskOptionsModal.propTypes = {
     onSave: PropTypes.func,
     projectId: PropTypes.number.isRequired,
     profile: PropTypes.object.isRequired,
-    discussActions: PropTypes.objectOf(PropTypes.func).isRequired,
-    taskActions: PropTypes.objectOf(PropTypes.func).isRequired,
-    userActions: PropTypes.objectOf(PropTypes.func).isRequired,
+    actions: PropTypes.objectOf(PropTypes.func).isRequired,
 };
 
 const mapDispatchToProps = dispatch => ({

--- a/src/views/ProjectManagement/components/Workflow/MatrixContainer.js
+++ b/src/views/ProjectManagement/components/Workflow/MatrixContainer.js
@@ -20,10 +20,7 @@ class MatrixContainer extends Component {
                         users={this.props.users}
                         profile={this.props.profile}
                         projectId={this.props.project.id}
-                        actions={this.props.actions}
-                        discussActions={this.props.discussActions}
-                        userActions={this.props.userActions}
-                        taskActions={this.props.taskActions} />}
+                        actions={this.props.actions} />}
                     <div className='matrix-container__task-matrix'>
                         <table className='table table-bordered workflow-table'
                             key='MatrixContainer'>


### PR DESCRIPTION
#### What's this PR do?
Fixes property references to let the Task Options Modal be displayed. Lacey needs this for some work she has to do.

#### Related JIRA tickets:
INBA-506.

#### How should this be manually tested?
Go to the project manager and hit the ellipsis (...) button to the top right of a task. The task options modal will display, resurrection from antiquity because we haven't touched it in forever. 

None of the functionality works because it has never been connected to the backend. I am working on another ticket (506) to do that now. 

#### Any background context you want to provide?
#### Screenshots (if appropriate):
