### PR TITLE
added a min-width media query to the spacer-container.

### DIFF
--- a/src/styles/projectmanagement/_sub-nav.scss
+++ b/src/styles/projectmanagement/_sub-nav.scss
@@ -2,14 +2,12 @@ $block-class: 'sub-nav';
 
 @at-root {
     .#{$block-class} {
-        &__spacer-container {
-            display: flex;
-            flex-direction: row;
-            justify-content: space-around;
+        display: flex;
+        flex-direction: row;
+        justify-content: space-around;
 
-            @media (min-width: 768px) {
-                width: 70%;
-            }
+        @media (min-width: 768px) {
+            width: 70%;
         }
     }
 }

--- a/src/views/ProjectManagement/components/SubNav/index.js
+++ b/src/views/ProjectManagement/components/SubNav/index.js
@@ -13,7 +13,7 @@ class SubNav extends Component {
         });
 
         return (
-            <div className='sub-nav__spacer-container'>
+            <div className='sub-nav'>
                 {subNavEntries.map((entry, i) =>
                     <SubNavEntry
                         {...entry}


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
Fixes the subnav spacing bunching.My intention was to keep the sub-nav at 75% spacing at a minimum of 768px. Im not sure if this is correct as im not sure if flex box handles media queries the as expected. Considering using display block or creating a separate query.scss file that declares multiple media query widths after mvp.
#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-538
#### How should this be manually tested?
just check if the nav bunches at 768px

#### Background/Context

#### Screenshots (if appropriate):
