### PR TITLE
Bug/INBA-245 Prevent stamp overflow

### DIFF
--- a/src/styles/_project-glance.scss
+++ b/src/styles/_project-glance.scss
@@ -5,6 +5,14 @@ $block-class: 'project-glance';
         display: flex;
         align-items: center;
         width: 100%;
-        justify-content: space-around;
+        flex-wrap: wrap;
+        justify-content: center;
+
+        &__group {
+            flex: 1;
+            display: flex;
+            justify-content: center;
+            margin: 4px 0;
+        }
     }
 }

--- a/src/styles/dashboard/_stamp.scss
+++ b/src/styles/dashboard/_stamp.scss
@@ -9,9 +9,10 @@ $neutral-color: #e6edef;
         flex: 1;
         border: 2px solid $neutral-color;
         border-radius: 50%;
-        margin: 8px;
+        margin: 0 8px;
         position: relative;
-        max-width: 150px;
+        max-width: 128px;
+        min-width: 100px;
 
         &--bad {
             border-color: $bad-color;

--- a/src/styles/userdashboard/_user-glance.scss
+++ b/src/styles/userdashboard/_user-glance.scss
@@ -5,5 +5,14 @@ $block-class: 'user-glance';
         display: flex;
         align-items: center;
         width: 100%;
+        flex-wrap: wrap;
+        justify-content: center;
+
+        &__group {
+            flex: 1;
+            display: flex;
+            justify-content: center;
+            margin: 4px 0;
+        }
     }
 }

--- a/src/views/PMDashboard/components/ProjectGlance.js
+++ b/src/views/PMDashboard/components/ProjectGlance.js
@@ -7,14 +7,18 @@ class ProjectGlance extends Component {
     render() {
         return (
             <div className='project-glance'>
-                <Stamp label={this.props.vocab.PROJECT.PROJECTS}
-                    value={this.props.projects} />
-                <Stamp label={this.props.vocab.PROJECT.STATUS_ACTIVE}
-                    value={this.props.active} />
-                <Stamp label={this.props.vocab.PROJECT.STATUS_INACTIVE}
-                    value={this.props.inactive} />
-                <Stamp label={this.props.vocab.PROJECT.FLAGS}
-                    value={this.props.flags} />
+                <div className='project-glance__group'>
+                    <Stamp label={this.props.vocab.PROJECT.PROJECTS}
+                        value={this.props.projects} />
+                    <Stamp label={this.props.vocab.PROJECT.STATUS_ACTIVE}
+                        value={this.props.active} />
+                </div>
+                <div className='project-glance__group'>
+                    <Stamp label={this.props.vocab.PROJECT.STATUS_INACTIVE}
+                        value={this.props.inactive} />
+                    <Stamp label={this.props.vocab.PROJECT.FLAGS}
+                        value={this.props.flags} />
+                </div>
             </div>
         );
     }

--- a/src/views/UserDashboard/components/UserGlance.js
+++ b/src/views/UserDashboard/components/UserGlance.js
@@ -7,16 +7,20 @@ class UserGlance extends Component {
     render() {
         return (
             <div className='user-glance'>
-                <Stamp label={this.props.vocab.PROJECT.TASKS_TO_DO}
-                    value={this.props.tasks} />
-                <Stamp label={this.props.vocab.PROJECT.NEW_TASK}
-                    value={this.props.newTasks}
-                    type={StampType.GOOD} />
-                <Stamp label={this.props.vocab.PROJECT.LATE_TASK}
-                    value={this.props.lateTasks}
-                    type={StampType.BAD} />
-                <Stamp label={this.props.vocab.PROJECT.FLAGGED}
-                    value={this.props.flagged} />
+                <div className='user-glance__group'>
+                    <Stamp label={this.props.vocab.PROJECT.TASKS_TO_DO}
+                        value={this.props.tasks} />
+                    <Stamp label={this.props.vocab.PROJECT.NEW_TASK}
+                        value={this.props.newTasks}
+                        type={StampType.GOOD} />
+                </div>
+                <div className='user-glance__group'>
+                    <Stamp label={this.props.vocab.PROJECT.LATE_TASK}
+                        value={this.props.lateTasks}
+                        type={StampType.BAD} />
+                    <Stamp label={this.props.vocab.PROJECT.FLAGGED}
+                        value={this.props.flagged} />
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
#### What does this PR do?
Prevent circles on the project and task dashboards from becoming so small that the contents escape the circles

#### Related JIRA tickets:
[INBA-245](https://jira.amida-tech.com/browse/INBA-245)

#### How should this be manually tested?
1. Load /task and /project and resize the window large and small
1. Check that the contents of the circles never overflow the circles

#### Background/Context

#### Screenshots (if appropriate):
