### PR TITLE
INBA-563 display weight input

### DIFF
--- a/src/styles/surveybuilder/_dynamic-question.scss
+++ b/src/styles/surveybuilder/_dynamic-question.scss
@@ -14,6 +14,7 @@ $block-class: 'dynamic-question';
         &__choices-fields {
             display: flex;
             flex-direction: row;
+            justify-content: space-between;
             margin: 2px 2px 2px 20px;
         }
 
@@ -36,6 +37,11 @@ $block-class: 'dynamic-question';
 
         &__scale {
 
+        }
+
+        &__weight-input {
+            width: 5%;
+            text-align: center;
         }
     }
 }

--- a/src/views/SurveyBuilder/components/DynamicQuestion.js
+++ b/src/views/SurveyBuilder/components/DynamicQuestion.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import IonIcon from 'react-ionicons';
 import PropTypes from 'prop-types';
+import { has } from 'lodash';
 
 class DynamicQuestion extends Component {
     render() {
@@ -16,35 +17,41 @@ class DynamicQuestion extends Component {
                         <div className='dynamic-question__choices-fields'
                             key={this.props.sectionIndex + this.props.questionIndex +
                                 this.props.question.type + index}>
-                            <input className='dynamic-question__choices-input'
-                                type='text'
-                                placeholder={this.props.vocab.SURVEY.CHOICE_ENTER}
-                                value={choice.text || ''}
-                                onChange={event =>
-                                    this.props.actions.upsertChoice(
-                                    this.props.sectionIndex,
-                                    this.props.questionIndex,
-                                    index,
-                                    event.target.value,
-                                )} />
-                            <button className='dynamic-question__masked-button'
-                                onClick={() => this.props.actions.upsertChoice(
-                                    this.props.sectionIndex,
-                                    this.props.questionIndex,
-                                    index,
-                                    )}>
-                                <IonIcon icon='ion-ios-plus'
-                                    className='dynamic-question__icon'/>
-                            </button>
-                            <button className='dynamic-question__masked-button'
-                                onClick={() => this.props.actions.deleteChoice(
-                                    this.props.sectionIndex,
-                                    this.props.questionIndex,
-                                    index,
-                                    )}>
-                                <IonIcon icon='ion-trash-b'
-                                    className='dynamic-question__icon'/>
-                            </button>
+                            <div className='dynamic-question__choices-group'>
+                                <input className='dynamic-question__choices-input'
+                                    type='text'
+                                    placeholder={this.props.vocab.SURVEY.CHOICE_ENTER}
+                                    value={choice.text || ''}
+                                    onChange={event =>
+                                        this.props.actions.upsertChoice(
+                                        this.props.sectionIndex,
+                                        this.props.questionIndex,
+                                        index,
+                                        event.target.value,
+                                    )} />
+                                <button className='dynamic-question__masked-button'
+                                    onClick={() => this.props.actions.upsertChoice(
+                                        this.props.sectionIndex,
+                                        this.props.questionIndex,
+                                        index,
+                                        )}>
+                                    <IonIcon icon='ion-ios-plus'
+                                        className='dynamic-question__icon'/>
+                                </button>
+                                <button className='dynamic-question__masked-button'
+                                    onClick={() => this.props.actions.deleteChoice(
+                                        this.props.sectionIndex,
+                                        this.props.questionIndex,
+                                        index,
+                                        )}>
+                                    <IonIcon icon='ion-trash-b'
+                                        className='dynamic-question__icon'/>
+                                </button>
+                            </div>
+                            {has(this.props.question, 'meta.weight') &&
+                                <input className='dynamic-question__weight-input'
+                                    placeholder={0} />
+                            }
                         </div>,
                             )}
                 </div>);

--- a/src/views/SurveyBuilder/components/QuestionPanel.js
+++ b/src/views/SurveyBuilder/components/QuestionPanel.js
@@ -188,7 +188,21 @@ class QuestionPanel extends Component {
                     {WEIGHTED.includes(this.props.question.type) &&
                         <div className='question-panel__checkboxes'>
                             <input type='checkbox'
-                                disabled={true} />
+                                value={has(this.props.question, 'meta.weight')}
+                                onChange={(event) => {
+                                    if (event.target.checked) {
+                                        this.props.actions.updateQuestion(
+                                            this.props.sectionIndex,
+                                            this.props.questionIndex,
+                                            'meta',
+                                            { weight: true });
+                                    } else {
+                                        this.props.actions.resetMeta(
+                                            this.props.sectionIndex,
+                                            this.props.questionIndex,
+                                            'weight');
+                                    }
+                                }}/>
                             <span className='question-panel__label'>
                                 {this.props.vocab.SURVEY.WEIGHT}
                             </span>


### PR DESCRIPTION
Behold, the absolute maximum of laziness.

#### What does this PR do?
Modifies the survey builder to allow you to click the "Weighted Question" checkbox and displays the inputs. Only works for the "Multiple Choice" questions right now because I need more requirement definitions. Also doesn't actually store any meaningful data. It really is just for display.

#### Related JIRA tickets:
INBA-564 - To actually store and make sense of the data.

#### How should this be manually tested?
Load up a survey, preferably a new one (you can use old). Insert a new question of type "Multiple Choice." Click on the "Weighted Value Question" and see that an input appears above it. 

Seriously.

That's it.

... It's, it's just for demo purposes.

INBA-564 will do the real work. I promise.


#### Background/Context

#### Screenshots (if appropriate):
