### PR TITLE
Bug/INBA-553 Restrict users in assign users dropdown

### DIFF
--- a/src/views/ProjectManagement/components/Workflow/StageSlot.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSlot.js
@@ -51,6 +51,7 @@ class StageSlot extends Component {
         super(props);
         this.handleTaskOptions = this.handleTaskOptions.bind(this);
         this.handleSearchSelect = this.handleSearchSelect.bind(this);
+        this.filterToStageGroups = this.filterToStageGroups.bind(this);
     }
 
     handleTaskOptions() {
@@ -63,6 +64,9 @@ class StageSlot extends Component {
         this.props.project,
         this.props.vocab);
         this.props.actions.startTaskAssign(false);
+    }
+    filterToStageGroups(user) {
+        return user.usergroupId.some(groupId => this.props.stageData.userGroups.includes(groupId));
     }
 
     displayDueTime(done, diff) {
@@ -145,6 +149,7 @@ class StageSlot extends Component {
                             fill={true}
                             inline={true}
                             suggestions={this.props.users
+                                .filter(this.filterToStageGroups)
                                 .map(user => ({ label: renderName(user),
                                     value: user }))}
                             onSelect={this.handleSearchSelect}


### PR DESCRIPTION
#### What does this PR do?
Restricts the users in the assign users dropdown to those users in groups assigned to the stage

#### Related JIRA tickets:
[INBA-533](https://jira.amida-tech.com/browse/INBA-533)

#### How should this be manually tested?
1. Open a project with a stage, with a group assigned to the stage, with some but not all users in the project assigned to that group
1. Click on assign task in a task and focus the input
1. Check that only users in the group assigned to the stage will appear in the list

#### Background/Context

#### Screenshots (if appropriate):
