### PR TITLE
styling/inba-554-cancel-status

### DIFF
--- a/src/views/ProjectManagement/components/Modals/StatusChange/SurveyStatusBody.js
+++ b/src/views/ProjectManagement/components/Modals/StatusChange/SurveyStatusBody.js
@@ -18,7 +18,7 @@ class SurveyStatusBody extends Component {
           <label htmlFor='survey-status-check' className='toggle'></label>
           <div className='project-status-field'>
             <div className='project-status-text'>
-              {this.props.published ? vocab.SURVEY.STATUS_PUBLISHED : vocab.SURVEY.STATUS_DRAFT}
+              {this.props.published ? vocab.SURVEY.PUBLISHED : vocab.SURVEY.DRAFT}
             </div>
             <div className='project-status-label'>{surveyVocab.VALUE_LABEL}</div>
           </div>

--- a/src/views/ProjectManagement/components/Modals/StatusChange/index.js
+++ b/src/views/ProjectManagement/components/Modals/StatusChange/index.js
@@ -69,7 +69,7 @@ class StatusChange extends Component {
                 class='project-status-change-layer'
                 title={title}
                 onSave={this.save.bind(this)}
-                onCancel={this.props.onStatusChangeClose}>
+                onCancel={() => this.props.actions.updateStatusChange(false)}>
                 {this.props.entity === 'project' ?
                     <ProjectStatusBody {...this.state.project}
                         vocab={this.props.vocab}


### PR DESCRIPTION

If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?

Provided prop that allows for Status Change modal cancellation. (Note: Because the Status Change modals are handling their state in the component and not through the redux state, we don't need to modify the reducer to reset their initial values for now). Also corrected a vocab reference for the Survey Status Change that will properly display the "Published" or "Draft" titles.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-554
#### How should this be manually tested?
go to an existing project
Click on the project status 
A modal should appear with a cancel button
Ensure that cancelling out of the modal restores original state.
#### Background/Context

#### Screenshots (if appropriate):
