### PR TITLE
Survey-top-instructions

### DIFF
--- a/src/styles/surveybuilder/_create-survey-panel.scss
+++ b/src/styles/surveybuilder/_create-survey-panel.scss
@@ -1,5 +1,3 @@
-$border-color: #dedede;
-
 $block-class: 'create-survey-panel';
 
 @at-root {
@@ -66,7 +64,6 @@ $block-class: 'create-survey-panel';
         &__survey-controls {
             padding: 16px;
             border: 1px solid $border-color;
-            border-collapse: collapse;
             display: flex;
             flex-direction: row;
             justify-content: flex-start;
@@ -78,24 +75,24 @@ $block-class: 'create-survey-panel';
             padding: 16px;
             border: 1px solid $border-color;
             color: $font-color;
+        }
 
-            &-entry {
-                border: 1px solid $border-color;
-                border-radius: 2px;
+        &__instructions-entry {
+            border: 1px solid $border-color;
+            border-radius: 2px;
+            padding: 8px;
+            color: $lead-font-color;
+            height: 5em;
+            resize: none;
+            margin-bottom: 4px;
+            margin-top: 4px;
+            background-color: #fafafa;
+
+            &:focus {
+                border: 2px solid $brand-color;
+                outline: none;
                 padding: 8px;
-                color: $lead-font-color;
-                height: 5em;
-                resize: none;
-                margin-bottom: 4px;
-                margin-top: 4px;
-                background-color: #fafafa;
-
-                &:focus {
-                    border: 2px solid $brand-color;
-                    outline: none;
-                    padding: 8px;
-                    box-sizing: border-box;
-                }
+                box-sizing: border-box;
             }
         }
 

--- a/src/views/SurveyBuilder/components/CreateSurveyPanel.js
+++ b/src/views/SurveyBuilder/components/CreateSurveyPanel.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Select from 'react-select';
-// import { Button } from 'grommet';
 import { toast } from 'react-toastify';
 
 import CreateSectionPanel from './CreateSectionPanel';


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
Styles the top portion of the survey builder
- Instructions
- View questions
- Expand All
- Collapse All
- Save Progress Button

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-599
#### How should this be manually tested?
Go to the survey builder
Compare the styling to the comp found here
https://projects.invisionapp.com/d/main#/console/10818602/235682951/preview
with an exception to the project and survey name.
Check for browser outlines that render on clicking an item. The focus state should be green, not blue per peters request for now. This is an accessibility issue that I plan to address later.
#### Background/Context
This ticket belongs to an epic
https://jira.amida-tech.com/browse/INBA-596
#### Screenshots (if appropriate):
