### PR TITLE
INBA-618: Tweak that returns the entire task.

### DIFF
--- a/src/common/actions/taskActions.js
+++ b/src/common/actions/taskActions.js
@@ -109,7 +109,7 @@ export function assignTask(userId, slot, project, errorMessages) {
                         requestBody,
                         (taskErr, taskResp) => {
                             dispatch(!taskErr && taskResp ?
-                                _postTaskSuccess(userId, slot, taskResp) :
+                                _postTaskSuccess(taskResp) :
                                 _reportTasksError(errorMessages.TASK_REQUEST));
                         },
                     );
@@ -204,16 +204,10 @@ function _getTasksByUserSuccess(userId, tasks) {
     };
 }
 
-function _postTaskSuccess(userId, slot, taskResp) {
+function _postTaskSuccess(taskResp) {
     return {
         type: actionTypes.POST_TASK_SUCCESS,
-        task: {
-            id: taskResp.id,
-            userIds: [userId],
-            stepId: slot.task.stepId,
-            uoaId: slot.task.uoaId,
-            endDate: slot.stageData.endDate,
-        },
+        task: taskResp,
     };
 }
 


### PR DESCRIPTION
#### What does this PR do?
Solves an obnoxious bug where you could not always force complete tasks if they were just assigned, because 

#### Related JIRA tickets:
There is a similarly named backend PR that goes with this.

#### How should this be manually tested?
Load this PR for both the front and back end. Create a project with pretty much everything: stages, subjects, users and groups, a survey. 

Assign a task, preferably to stage 1. Without refreshing, click on the Task Options modal (...) and choose "Force Complete." It should succeed with no error. 

You may also try laying down two tasks in a row and forcing one to complete. 

#### Background/Context
Before, tasks were being populated by a small amount of data when first created (6 items in an object). After refreshing the page, the backend returned pretty much everything (19 keys). One of these was the productId, which the prior 6-item object code was not accounting for. 

Rather than half ass it, I went ahead and just return the newly created task and immediately populate that into the reducer. 

#### Screenshots (if appropriate):
