### PR TITLE
INBA-388 / Allow Auth Service Version to be Configured

### DIFF
--- a/src/config/development.js
+++ b/src/config/development.js
@@ -1,10 +1,12 @@
+const AUTH_API_VERSION = process.env.AUTH_API_VERSION || 'v0';
+
 export default {
     NODE_ENV: 'development',
     API_HTTP_URL: process.env.API_HTTP_URL || 'http://localhost:3005',
     API_HTTPS_URL: process.env.API_HTTPS_URL || 'http://localhost:3005',
 
-    AUTH_API_HTTP_URL: process.env.AUTH_API_HTTP_URL || 'http://localhost:4000/api/v0',
-    AUTH_API_HTTPS_URL: process.env.AUTH_API_HTTPS_URL || 'https://localhost:4000/api/v0',
+    AUTH_API_HTTP_URL: process.env.AUTH_API_HTTP_URL || `http://localhost:4000/api/${AUTH_API_VERSION}`,
+    AUTH_API_HTTPS_URL: process.env.AUTH_API_HTTPS_URL || `https://localhost:4000/api/${AUTH_API_VERSION}`,
 
     SURVEY_API_HTTP_URL: process.env.SURVEY_API_HTTP_URL || 'http://localhost:9005/api/v1.0',
     SURVEY_API_HTTPS_URL: process.env.SURVEY_API_HTTPS_URL || 'https://localhost:9005/api/v1.0',

--- a/src/config/staging.js
+++ b/src/config/staging.js
@@ -1,10 +1,12 @@
+const AUTH_API_VERSION = process.env.AUTH_API_VERSION || 'v0';
+
 export default {
     NODE_ENV: 'staging',
     API_HTTP_URL: process.env.API_HTTP_URL || 'http://openshift.amida.com/',
     API_HTTPS_URL: process.env.API_HTTPS_URL || 'https://openshift.amida.com/',
 
-    AUTH_API_HTTP_URL: process.env.AUTH_API_HTTP_URL || 'http://openshift.amida.com/api/v0',
-    AUTH_API_HTTPS_URL: process.env.AUTH_API_HTTPS_URL || 'https://openshift.amida.com/api/v0',
+    AUTH_API_HTTP_URL: process.env.AUTH_API_HTTP_URL || `http://openshift.amida.com/api/${AUTH_API_VERSION}`,
+    AUTH_API_HTTPS_URL: process.env.AUTH_API_HTTPS_URL || `https://openshift.amida.com/api/${AUTH_API_VERSION}`,
     REALM: 'testorg',
 
     SYS_MESSAGE_USER: process.env.SYS_MESSAGE_USER,


### PR DESCRIPTION
PR called for the ability to set the version of the authentication service independently of the authentication URL... I really don't know why you want this, and I don't think we really do. But since it only took 5 minutes, here ya go. 

#### What does this PR do?
Allows the auth service URL's version to be changed as a separate .env variable, with `v0` as the default value. 

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-388

#### How should this be manually tested?
Easiest way is to confirm that you can log in normally with any user. Then go change your Indaba-client `.env` file to include `AUTH_API_VERSION`. Change that value to something else, say `v1`.  Restart, then try to log in. Check the network tab to confirm that it failed for your perverse amusement. 

#### Background/Context
I don't know why we're yelling.

#### Screenshots (if appropriate):
