### PR TITLE
Hotfix/INBA-610 Incorrect constant for NODE_ENV comparison

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,7 @@ import './styles/main.scss';
 import reducers from './reducers';
 import routes from './routes';
 
-const DEVELOP = process.env.NODE_ENV === 'develop';
+const DEVELOP = process.env.NODE_ENV === 'development';
 
 let middleware = [routerMiddleware(browserHistory), thunk];
 if (DEVELOP) {


### PR DESCRIPTION
#### What does this PR do?
Changes a constant from `'develop'` to `'development'` in a comparison to `NODE_ENV` for enabling dev tools

#### Related JIRA tickets:
Bug introduced by [INBA-610](https://jira.amida-tech.com/browse/INBA-610)

#### How should this be manually tested?
Run `yarn develop` and check that you can open the development tools with Ctrl+h

#### Background/Context

#### Screenshots (if appropriate):
