### PR TITLE
INBA-634 Disable dropdown when input is disallowed

### DIFF
--- a/src/views/TaskReview/components/Questions/Dropdown.js
+++ b/src/views/TaskReview/components/Questions/Dropdown.js
@@ -12,16 +12,28 @@ class Dropdown extends Component {
         }
         return (
             <div className='dropdown'>
-                <Select className='dropdown__field'
-                    value={currentValue}
-                    placeHolder={this.props.vocab.PROJECT.SELECT_OPTION}
-                    readonly={this.props.displayMode}
-                    options={this.props.choices.map((entry) => {
-                        return { label: entry.text, value: entry.id };
-                    })}
-                    onChange={(event) => {
-                        this.props.upsertAnswer({ choice: event.option.value });
-                    }} />
+                {
+                    this.props.displayMode ?
+
+                    <select className='dropdown__field'
+                        value={currentValue}
+                        placeholder={this.props.vocab.PROJECT.SELECT_OPTION}
+                        disabled={true}>
+                        <option className='dropdown__option'
+                            label={currentValue} />
+                    </select> :
+
+                    <Select className='dropdown__field'
+                        value={currentValue}
+                        placeHolder={this.props.vocab.PROJECT.SELECT_OPTION}
+                        readonly={this.props.displayMode}
+                        options={this.props.choices.map((entry) => {
+                            return { label: entry.text, value: entry.id };
+                        })}
+                        onChange={(event) => {
+                            this.props.upsertAnswer({ choice: event.option.value });
+                        }} />
+                }
             </div>
         );
     }


### PR DESCRIPTION
Fixed dropdown question still live in “completed” task

#### What does this PR do?
In surveys with questions that have "Choices", when in displayMode, the questions were still being shown as a dropdown. This PR fixes that

#### Related JIRA tickets:
[INBA-634](https://jira.amida-tech.com/browe/INBA-634)

#### How should this be manually tested?
Create a survey with questions that have choices. Make sure that users see a dropdown when the survey is an editable mode. and that the dropdown is readonly when the survey is not in an editable mode

#### Background/Context

#### Screenshots (if appropriate):
