### PR TITLE
Bug/INBA-584 Task flag count position and size

### DIFF
--- a/src/styles/dashboard/_flag-count.scss
+++ b/src/styles/dashboard/_flag-count.scss
@@ -14,14 +14,14 @@ $block-class: 'flag-count';
             position: absolute;
             top: 0;
             left: 16px;
-            width: 18px;
-            height: 18px;
+            width: 14px;
+            height: 14px;
             color: $font-inverse-color;
             background-color: $brand-color;
             border-radius: 50%;
-            font-size: 12px;
+            font-size: 10px;
             text-align: center;
-            line-height: 18px;
+            line-height: 16px;
         }
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Moves the task flag count circle to the left so that it overlaps the flag icon again after the flag icon size was reduced.

#### Related JIRA tickets:
[INBA-584](https://jira.amida-tech.com/browse/INBA-584)

#### How should this be manually tested?
1. Generate a task for a user with at least one flag
1. Go to /task as that user
1. Check that the green circle with the flag count overlaps the flag

#### Background/Context
@laceyIrvin I had to make the flag count circle and number smaller to match the flag icon, and it's quite small now. We might consider whether the flag icon and circle can be reverted to the larger size.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/51333/35345808-9a6cc2fc-00fe-11e8-91ee-1f77e764b03c.png)

