### PR TITLE
Bug/INBA-632 Task summary update

### DIFF
--- a/src/views/UserDashboard/reducer.js
+++ b/src/views/UserDashboard/reducer.js
@@ -36,11 +36,11 @@ export default (state = initialState, action) => {
         });
     case actionTypes.USER_DASH_GET_ANSWERS_SUCCESS:
         return update(state, {
-            answers: { $apply: answers => unionBy(answers, [action.answers], 'assessmentId'),
+            answers: { $apply: answers => unionBy([action.answers], answers, 'assessmentId'),
             } });
     case actionTypes.USER_DASH_GET_SURVEY_BY_ID_SUCCESS:
         return update(state, {
-            surveys: { $apply: surveys => unionBy(surveys, [action.survey], 'id'),
+            surveys: { $apply: surveys => unionBy([action.survey], surveys, 'id'),
             } });
     default:
         return state;


### PR DESCRIPTION
#### What does this PR do?
Fixes the user dashboard's reducer to use newly retrieved answer and survey data on component mount, resolving an issue where the progress would not change after answering questions.

#### Related JIRA tickets:
[INBA-632](https://jira.amida-tech.com/browse/INBA-632)

#### How should this be manually tested?
1. Create a survey with several questions, assign a task to complete the survey to a user
1. Log in as the user and go to /task
1. Note the value Progress column for the task
1. Complete the remaining steps _without refreshing_
1. Click the task to get to the survey
1. Answer a question
1. Click Back to return to the task list
1. Check that the progress column has incremented to include the newly answered question

#### Background/Context

#### Screenshots (if appropriate):
