### PR TITLE
Bug/INBA-635 No premature tasks in user task list

### DIFF
--- a/src/views/UserDashboard/components/index.js
+++ b/src/views/UserDashboard/components/index.js
@@ -94,8 +94,9 @@ const mapStateToProps = state => ({
     messages: state.userdashboard.messages.slice(0, 4),
     ui: state.userdashboard.ui,
     users: state.user.users,
-    rows: state.userdashboard.tasks.map(task =>
-        _generateRow(state, task.projectId, task)),
+    rows: state.userdashboard.tasks
+        .filter(task => task.complete || task.active)
+        .map(task => _generateRow(state, task.projectId, task)),
 });
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
#### What does this PR do?
Filters tasks in the user dashboard down to those that are active or complete, hiding those that cannot yet be started by the user.

Requires backend on https://github.com/amida-tech/greyscale/pull/436

#### Related JIRA tickets:
[INBA-635](https://jira.amida-tech.com/browse/INBA-635)

#### How should this be manually tested?
1. Assign two tasks in a row to a user, the first being active
1. Go to /task as the user
1. Check that only the first task appears in the task list
1. Complete the task
1. Check that the second task now appears in the task list

#### Background/Context

#### Screenshots (if appropriate):
