### PR TITLE
INBA-687 / Includes proper stage position with the putStage.

### DIFF
--- a/src/common/actions/projectActions.js
+++ b/src/common/actions/projectActions.js
@@ -87,7 +87,6 @@ export function putStage(project, stage, fromWizard, errorMessages) {
         stage,
         {
             workflowId: project.workflowId,
-            position: project.stages.length,
             role: 3,
             startDate: new Date(stage.startDate),
             endDate: new Date(stage.endDate),

--- a/src/views/ProjectManagement/components/Modals/Stage/index.js
+++ b/src/views/ProjectManagement/components/Modals/Stage/index.js
@@ -32,6 +32,7 @@ class StageModal extends Component {
             initialValues = {
                 title: '',
                 userGroups: [],
+                position: this.props.project.stages.length,
                 permissions: '0',
                 startDate: '',
                 endDate: '',
@@ -80,6 +81,7 @@ const stageMapping = (values) => {
         startDate: values.startDate,
         endDate: values.endDate,
         userGroups: values.userGroups,
+        position: values.position,
         provideResponses: true,
         discussionParticipation: false,
         blindReview: false,


### PR DESCRIPTION
Note, although there is an identically named PR for the backend. Although it seems like it only takes care of the delete aspect of this problem, you need it for testing the `isDeleted` in tandem.

#### What does this PR do?
For the front end, fixes an issue where the stage was accidentally being incremented improperly due to basing itself on the project stage array size at all times. Now it only does so for totally new stages, and bases itself on the old position if the stage is being edited.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-687

#### How should this be manually tested?
Check The `WorkflowSteps` table to monitor the effects.

On a workflow, try adding a new stage. Go to the table and ensure that position is the whatever the latest stage's position is, plus 1.  All the stages in a project will share the same `workflowId`, but the id will increment. 

Try editing a stage. Submit then check the table and ensure that the position has not changed. 

Try deleting a stage midstream. Go to the table and ensure both that the `isDeleted` column has been filled and the other stages' whose positions are _after_ that stage have decreased by 1. 

You may also wish to test and ensure that the workflow progresses upon task completion (this was breaking that).

#### Background/Context

#### Screenshots (if appropriate):
