### PR TITLE
Bug/INBA-694 Survey wizard circle on wizard complete screen

### DIFF
--- a/src/views/CreateProjectWizard/components/WizardComplete.js
+++ b/src/views/CreateProjectWizard/components/WizardComplete.js
@@ -1,17 +1,22 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Tabs, Tab, Button } from 'grommet';
+import { has, get } from 'lodash';
+
 import Modal from '../../../common/components/Modal';
 
 class WizardComplete extends Component {
     render() {
+        const surveyComplete = has(this.props.survey, 'id') &&
+            get(this.props.survey, 'sections', []).length > 0 &&
+            this.props.survey.sections.some(section => section.questions.length > 0);
         return <Modal>
             <div className='wizard-complete'>
                 <h1 className='wizard-complete__header'>
                     {this.props.vocab.PROJECT.PROJECT_CREATE_SUCCESS}
                 </h1>
                 <Tabs className='wizard-complete__tabs'>
-                    <Tab className='wizard-complete__tab wizard-complete__tab--incomplete'
+                    <Tab className={`wizard-complete__tab wizard-complete__tab--${surveyComplete ? 'complete' : 'incomplete'}`}
                         title={this.props.vocab.PROJECT.CREATE_SURVEY}>
                     </Tab>
                     <Tab className={`wizard-complete__tab wizard-complete__tab--${this.props.project.subjects.length > 0 ? 'complete' : 'incomplete'}`}

--- a/src/views/CreateProjectWizard/components/index.js
+++ b/src/views/CreateProjectWizard/components/index.js
@@ -156,7 +156,8 @@ class CreateProjectWizard extends Component {
                 <WizardComplete
                     vocab={this.props.vocab}
                     projectLink={this.props.ui.projectLink}
-                    project={this.props.project} />
+                    project={this.props.project}
+                    survey={this.props.survey}/>
             </div>);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Colors the survey circle on the wizard complete screen if the survey is created

#### Related JIRA tickets:
[INBA-694](https://jira.amida-tech.com/browse/INBA-694)

#### How should this be manually tested?
1. Create a project in the wizard
1. Make a survey with questions
1. Do the rest
1. Hit Complete Wizard
1. Check that the circle for the survey step is green
1. Do the same without adding a valid survey, check that the circle is not green

#### Background/Context

#### Screenshots (if appropriate):
Left most circle should be green iff the survey was added and has questions
![image](https://user-images.githubusercontent.com/51333/35817503-8e0c39ae-0a6b-11e8-94c2-902bef911420.png)

