### PR TITLE
Revise text size on Stage modal

### DIFF
--- a/src/styles/modals/stage/_stage-form.scss
+++ b/src/styles/modals/stage/_stage-form.scss
@@ -65,6 +65,7 @@ $block-class:'stage-form';
 
         &__permission-label-text {
             color: $form-text;
+            font-size: 16px;
             font-weight: 400;
             margin-left: 8px;
             margin-right: 16px;


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
Changes the permission label font size to 16px
#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-695
#### How should this be manually tested?
Go to the stage modal
The permission radio buttons should be 16px
#### Background/Context

#### Screenshots (if appropriate):
