### PR TITLE
Bug/INBA-690 Don't show tasks from inactive projects

### DIFF
--- a/src/views/UserDashboard/components/index.js
+++ b/src/views/UserDashboard/components/index.js
@@ -96,7 +96,7 @@ const mapStateToProps = state => ({
     users: state.user.users,
     rows: state.userdashboard.tasks
         .filter(task => task.complete || task.active)
-        // omit any tasks in projects that are inactive (hiding all beforr project data is loaded)
+        // omit any tasks in projects that are inactive (hiding all before project data is loaded)
         .filter(task => get(
             state.projects.data.find(findProject => findProject.id === task.projectId),
             'status',


### PR DESCRIPTION
#### What does this PR do?
Filters tasks out from the user dashboard that are in projects that are not active

#### Related JIRA tickets:
[INBA-690](https://jira.amida-tech.com/browse/INBA-690)

#### How should this be manually tested?
1. Make a project
1. Assign some tasks to a user
1. Make the project inactive
1. Check that those tasks do not appear in the user's task list at /task

#### Background/Context
Tasks are still counted in the circles in the top right, to be fixed in [INBA-714](https://jira.amida-tech.com/browse/INBA-714)

#### Screenshots (if appropriate):
