### PR TITLE
Feature/INBA-709 Save survey on continue

### DIFF
--- a/src/views/CreateProjectWizard/components/index.js
+++ b/src/views/CreateProjectWizard/components/index.js
@@ -48,6 +48,13 @@ class CreateProjectWizard extends Component {
     }
     handleContinue() {
         if (this.props.ui.step < NUM_WIZARD_STEPS - 1) {
+            if (this.props.ui.step === 0) {
+                this.props.actions.patchSurvey(
+                    this.props.inProgressSurvey,
+                    this.props.vocab.SURVEY.SUCCESS,
+                    this.props.vocab.ERROR,
+                );
+            }
             this.changeStep(this.props.ui.step + 1);
         } else {
             this.props.actions.showCompleteWizard(true);
@@ -184,6 +191,7 @@ const mapStateToProps = (state) => {
         project,
         survey: find(state.surveys.data, survey => survey.id === project.surveyId) ||
             { id: -1, name: state.surveys.ui.newSurveyName, status: 'draft', sections: [] },
+        inProgressSurvey: state.surveybuilder.form,
         user: state.user,
         ui: state.wizard.ui,
         vocab: state.settings.language.vocabulary,


### PR DESCRIPTION
#### What does this PR do?
Save the current form state to the survey when the user clicks Continue on the survey step

#### Related JIRA tickets:
[INBA-709](https://jira.amida-tech.com/browse/INBA-709)

#### How should this be manually tested?
1. Start a project wizard
1. Give the project a name
1. Fill out one or more questions but do not save
1. Click Continue
1. Check that you see a toast indicating the survey was saved, and that the questions added persist in the survey

#### Background/Context

#### Screenshots (if appropriate):
