### PR TITLE
Bug/INBA-710 Flag counts in user dashboard

### DIFF
--- a/src/views/UserDashboard/components/index.js
+++ b/src/views/UserDashboard/components/index.js
@@ -96,7 +96,7 @@ const mapStateToProps = (state) => {
             tasks: rows.filter(row => !row.complete).length,
             newTasks: rows.filter(row => row.new).length,
             lateTasks: rows.filter(row => row.late).length,
-            flagged: state.userdashboard.tasks.filter(task => task.flagCounter > 0).length,
+            flagged: rows.filter(row => row.flags > 0).length,
         },
         profile: state.user.profile,
         vocab: state.settings.language.vocabulary,


### PR DESCRIPTION
#### What does this PR do?
Fixes the calculation of the flag counts in the user dashboard

#### Related JIRA tickets:
[INBA-710](https://jira.amida-tech.com/browse/INBA-710)

#### How should this be manually tested?
1. Populate a discussion with flags on several questions
1. Log in as the user assigned to the tasks with flags
1. Go to the task list and check that the number of flags is correct in the circles and in the task lists
1. Log in as the user notified when the discussion was started (not the user assigned to the task)
1. Check that the task list and circles show the correct number of flags

#### Background/Context

#### Screenshots (if appropriate):
