### PR TITLE
Bug/INBA-719 Cancel on forward message

### DIFF
--- a/src/views/Messages/Message/components/Message.js
+++ b/src/views/Messages/Message/components/Message.js
@@ -183,7 +183,7 @@ class MessageSelector extends Component {
     }
     cancelForm() {
         const reply = this.props.reply || _.get(this.props, 'location.state.message');
-        if (_.has(reply, 'id')) {
+        if (_.has(reply, 'id') || _.has(reply, 'forwardId')) {
             this.props.actions.discardReply();
         } else {
             this.props.goToInbox();


### PR DESCRIPTION
#### What does this PR do?
Fix error and (attempted) behavior on cancelling a forwarded message. Message compose form is now removed instead of attempting to go back to the inbox

#### Related JIRA tickets:
[INBA-719](https://jira.amida-tech.com/browse/INBA-719)

#### How should this be manually tested?
1. Open a message
1. Click forward
1. Click cancel
1. Check that there is no error and that the message compose form is removed

#### Background/Context

#### Screenshots (if appropriate):
