### PR TITLE
INBA-701 - Tasks always "Not Started" fix.

### DIFF
--- a/src/utils/TaskStatus.js
+++ b/src/utils/TaskStatus.js
@@ -1,9 +1,4 @@
 export default {
-// methods to determine filter status
-    responsesExist(task) {
-        return task.response &&
-            task.response.some(response => response.value !== undefined);
-    },
     responsesComplete(task, surveySize) {
         return task.response &&
             task.response.every(response => response.value !== undefined) &&

--- a/src/views/ProjectManagement/components/Workflow/FilteredRow.js
+++ b/src/views/ProjectManagement/components/Workflow/FilteredRow.js
@@ -7,7 +7,7 @@ import TaskStatus from '../../../../utils/TaskStatus';
 const _taskLookup = (stage, subjectId, tasks, responses) => {
     const newTask = Object.assign({}, tasks.find(
         element => element.uoaId === subjectId && element.stepId === stage.id) ||
-        { stepId: stage.id, uoaId: subjectId, userIds: [] });
+        { stepId: stage.id, uoaId: subjectId, userIds: [], assessmentStatus: 'new', flagHistory: false });
     const response = _.find(responses, chat => chat.taskId === newTask.id);
     if (response) newTask.response = response.discuss;
     return newTask;
@@ -20,16 +20,13 @@ class FilteredRow extends Component {
             return !_.isEmpty(taskData.userIds);
         case 'late':
             return !taskData.userIds ||
-                (!(TaskStatus.endDateInPast(taskData) &&
-                !TaskStatus.responsesComplete(taskData, this.props.surveySize)));
+                (!(TaskStatus.endDateInPast(taskData) && taskData.status !== 'completed'));
         case 'inprogress':
-            return !taskData.userIds ||
-                (!(TaskStatus.responsesExist(taskData) &&
-                !TaskStatus.responsesComplete(taskData, this.props.surveySize)));
+            return !taskData.userIds || taskData.status === 'completed' || (!taskData.flagHistory && taskData.assessmentStatus === 'new');
         case 'notstarted':
-            return !taskData.userIds || TaskStatus.responsesExist(taskData);
+            return !taskData.userIds || taskData.status === 'completed' || taskData.flagHistory || taskData.assessmentStatus === 'in-progress';
         case 'flagged':
-            return !taskData.userIds || !TaskStatus.responsesFlagged(taskData);
+            return !taskData.userIds || !taskData.flagged;
         default:
             return '';
         }

--- a/src/views/ProjectManagement/components/Workflow/StageSlot.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSlot.js
@@ -87,7 +87,7 @@ class StageSlot extends Component {
         if (diff <= 0) {
             return { label: this.props.vocab.PROJECT.CARD.LATE, type: StatusLabelType.BAD };
         }
-        if (!TaskStatus.responsesExist(this.props.task)) {
+        if (!this.props.task.flagHistory && this.props.task.assessmentStatus === 'new') {
             return {
                 label: this.props.vocab.PROJECT.CARD.NOT_STARTED,
                 type: StatusLabelType.NEUTRAL };
@@ -99,7 +99,7 @@ class StageSlot extends Component {
         const { isOver, canDrop, connectDropTarget } = this.props;
 
         const diff = TaskStatus.daysUntilDue(this.props.task);
-        const done = TaskStatus.responsesComplete(this.props.task, this.props.surveySize);
+        const done = this.props.task.status === 'completed';
 
         const labelDisplay = this.displayStatus(done, diff);
         let stageClass = 'stage-slot ';


### PR DESCRIPTION
#### What does this PR do?
There is an essential backend component to this. Please deploy both. 

Changes and fixes the filtering and displays for the Project Matrix so that they will read "Not Started" if the task has all the below: 

1. Has no answered questions.
2. Isn't flagged.
3. Has never been flagged.

If any of these aren't true, the task has started and is "in progress." Because discussions don't carry over from stage to stage, these facts still apply to the following stages.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-701

#### How should this be manually tested?
I recommend you create a brand new survey and four subjects. Assign users and make:

1. One with a single question answered.
2. One with a current flag.
3. One with a flag that another user resolved. 
4. One that is completely untouched.

Then check the filters to make sure that all is correct. 

Also, please check filter conditions for making a task late, and completed and for unassigned slots, and please check them carefully. You can modify a task's due date either by manipulating the `endDate` column in the `Tasks` table, or if INBA-650 is merged in by the time you get to this. 

**Please note that the "new" status in the User Dashboard doesn't apply to tasks that have discussions, only if they have answered questions or not.** We may revise this later, but I want that to be a separate ticket.


#### Background/Context

#### Screenshots (if appropriate):
