### PR TITLE
Bug/INBA-725 Flag question list broken in firefox

### DIFF
--- a/src/views/TaskReview/components/FlagSidebar/FlagQuestionList.js
+++ b/src/views/TaskReview/components/FlagSidebar/FlagQuestionList.js
@@ -33,7 +33,8 @@ class FlagQuestionList extends Component {
                     return (
                         <div key={`listitem${question}${index}`}
                             className={`flag-question-list__item flag-question-list__item${modifier}`}
-                            onClick={this.onChangeQuestion.bind(event, question.id, index)}>
+                            onClick={() =>
+                                this.onChangeQuestion(question.id, index)}>
                             {this.props.vocab.PROJECT.QUESTION_ + (index + 1) }
                         </div>
                     );


### PR DESCRIPTION
#### What does this PR do?
Fixes the click handler for the flag question list that was breaking rendering on firefox

#### Related JIRA tickets:
[INBA-725](https://jira.amida-tech.com/browse/INBA-725)

#### How should this be manually tested?
1. Open a task in firefox
1. Check that the flag question list renders and that you can click on them

#### Background/Context
`event` is not defined there. Chrome doesn't seem to mind but Firefox does

#### Screenshots (if appropriate):
