### PR TITLE
INBA-724 Change that renders meta data fields disabled if the task is.

### DIFF
--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -114,7 +114,7 @@ class Questions extends Component {
                             </span>
                             <input className='questions__link-input'
                                 type='text'
-                                disabled={noValue}
+                                disabled={noValue || this.props.displayMode}
                                 defaultValue={get(value, 'meta.publication.link', '')}
                                 onBlur={event => this.props.actions.upsertAnswer(
                                     this.props.assessmentId,
@@ -127,7 +127,7 @@ class Questions extends Component {
                         <div className='questions__link-fields-bottom'>
                             <input className='questions__title-input'
                                 type='text'
-                                disabled={noValue}
+                                disabled={noValue || this.props.displayMode}
                                 defaultValue={get(value, 'meta.publication.title', '')}
                                 placeholder={this.props.vocab.SURVEY.ENTER_PUBLICATION}
                                 onBlur={event => this.props.actions.upsertAnswer(
@@ -139,7 +139,7 @@ class Questions extends Component {
                                     this.props.vocab.ERROR)} />
                             <input className='questions__author-input'
                                 type='text'
-                                disabled={noValue}
+                                disabled={noValue || this.props.displayMode}
                                 defaultValue={get(value, 'meta.publication.author', '')}
                                 placeholder={this.props.vocab.SURVEY.AUTHOR}
                                 onBlur={event => this.props.actions.upsertAnswer(
@@ -149,10 +149,10 @@ class Questions extends Component {
                                     merge(value.meta,
                                         { publication: { author: event.target.value } }),
                                     this.props.vocab.ERROR)} />
-                                { noValue ?
+                                { (noValue || this.props.displayMode) ?
                                     <input className='questions__date-disabled'
-                                        type='date'
-                                        disabled /> :
+                                        value={get(value, 'meta.publication.date', 'MM/DD/YYYY')}
+                                        disabled={true} /> :
                                     <DateTime className='questions__date-input'
                                         value={get(value, 'meta.publication.date', '')}
                                         format='MM/DD/YYYY'


### PR DESCRIPTION
#### What does this PR do?
Disabled "Add Link" meta fields when the task is completed.

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-724

#### How should this be manually tested?
For either an existing project or a newly created one, ensure that some of the questions have the "Add Link" meta data field clicked.

Login as that user and complete the task, adding data to those meta data fields.

Upon completion, check that the metadata fields are no longer enabled. Log out and login as the admin and go to that task. The meta fields should remain disabled.

#### Background/Context

#### Screenshots (if appropriate):
