### PR TITLE
Bug/INBA-704 Disable date in review

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -347,6 +347,7 @@
         "PERMISSIONS": "Permissions"
     },
     "SURVEY": {
+        "NO_DATE_ENTERED": "No date entered",
         "RETIRED": "Retired",
         "DRAFT": "Draft",
         "PUBLISHED": "Published",

--- a/src/views/TaskReview/components/Questions/Date.js
+++ b/src/views/TaskReview/components/Questions/Date.js
@@ -13,10 +13,14 @@ class Date extends Component {
         return (
             <div className='date'>
                 {
-                    this.props.displayMode ?
-                    <div className='date__field'>
-                        {currentAnswer}
-                    </div> :
+                    (this.props.displayMode &&
+                    (
+                        currentAnswer ?
+                        <div className='date__field'>
+                            {currentAnswer}
+                        </div> :
+                        this.props.vocab.SURVEY.NO_DATE_ENTERED
+                    )) ||
                     <DateTime className='date__field'
                         value={currentAnswer}
                         format='MM/DD/YYYY'


### PR DESCRIPTION
#### What does this PR do?
Renders a plaintext date when a survey is non-editable

#### Related JIRA tickets:
[INBA-704](https://jira.amida-tech.com/browse/INBA-704)

#### How should this be manually tested?
1. Make a survey with a date in it, assign a user to complete the survey, and a user to review
1. Complete the survey with a value for the date
1. Go to the review and check that the date display is plaintext
1. Complete a survey without adding a value for the date
1. Go to the review and check that a sensible message is displayed for the absent value

#### Background/Context

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/51333/36043993-265e9900-0d9f-11e8-9bdb-d43c02bc67fd.png)

