### PR TITLE
Bug/INBA-744 Render crash with empty section

### DIFF
--- a/src/views/SurveyBuilder/components/CreateSectionPanel.js
+++ b/src/views/SurveyBuilder/components/CreateSectionPanel.js
@@ -30,7 +30,8 @@ class CreateSectionPanel extends Component {
                             className='create-section-panel__menu-icon'/>
                     </button>
                 </div>
-                {this.props.section.questions.map((question, questionIndex) => (
+                {this.props.section.questions &&
+                    this.props.section.questions.map((question, questionIndex) => (
                     <QuestionPanel className='create-section-panel__question'
                         key={`key-question-${questionIndex}`}
                         sectionIndex={this.props.sectionIndex}


### PR DESCRIPTION
#### What does this PR do?
Prevents the survey builder render from crashing when a section contains no questions

#### Related JIRA tickets:
[INBA-744](https://jira.amida-tech.com/browse/INBA-744)

#### How should this be manually tested?
1. Create a survey and add a section without adding questions to it
1. Refresh and go to the survey tab of the project
1. Check that the survey and empty section render without crashing

#### Background/Context

#### Screenshots (if appropriate):
