### PR TITLE
Feature/INBA-537 Mark as read without direct load

### DIFF
--- a/src/views/Messages/Message/components/index.js
+++ b/src/views/Messages/Message/components/index.js
@@ -81,7 +81,10 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = dispatch => ({
     actions: bindActionCreators(Object.assign({}, actions), dispatch),
-    goToMessage: id => dispatch(push(`/messages/${id}`)),
+    goToMessage: (id) => {
+        dispatch(actions.markAsRead(id));
+        dispatch(push(`/messages/${id}`));
+    },
     goToInbox: () => dispatch(push('/messages')),
 });
 


### PR DESCRIPTION
#### What does this PR do?
Fixes a bug in the first INBA-537 implementation where a message was only marked as read when opening a thread the first time. Clicking on another message in the thread now marks that message as read.

#### Related JIRA tickets:
[INBA-537](https://jira.amida-tech.com/browse/INBA-537)

#### How should this be manually tested?
1. Send a message to User A
1. Respond to that message as User A
1. Respond to the response as another user
1. As user A, check that the most recent message appears in Unread, but _don't_ click on it there
1. Go to All Messages and click the thread
1. Click on the most recent message
1. Go back to the inbox and check that the message no longer appears in Unread

#### Background/Context

#### Screenshots (if appropriate):
