### PR TITLE
INBA-756/ Disable but show task review's add file..

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -85,6 +85,7 @@
         "NO_DELETE_USER_GROUP_WITH_STAGES": "This user group is currently assigned to one or more workflow stages and may not be deleted.",
         "NOTIFY_FAILURE": "The system was unable to notify the user of this action",
         "FILE_UPLOAD": "Failed to upload the file.",
+        "FILE_WARNING": "Please choose a file pertinent to your answer, then click the 'Add File' button.",
         "REQUIRE_ANSWERS": "Please answer all required questions.",
         "FLAGGED_QUESTIONS": "You cannot complete a task if there are flagged questions awaiting resolution.",
         "INVALID_TOKEN": "The activation token is invalid. Your account has not been activated",

--- a/src/styles/taskreview/_file-form.scss
+++ b/src/styles/taskreview/_file-form.scss
@@ -18,12 +18,18 @@ $block-class: 'file-form';
         }
 
         &__submit {
+            color: #333;
+
             &--remove {
                 margin-left: 8px;
             }
 
             &--add {
                 margin-top: 4px;
+            }
+
+            &:disabled {
+                color: graytext;
             }
         }
 

--- a/src/views/TaskReview/components/Questions/FileForm.js
+++ b/src/views/TaskReview/components/Questions/FileForm.js
@@ -12,7 +12,7 @@ class FileForm extends Component {
             <form className='file-form'
                 onSubmit={this.props.handleSubmit}>
                 {
-                    this.props.file === undefined && !this.props.disabled &&
+                    this.props.file === undefined &&
                     <div className='file-form__add-form'>
                         <Field name={'file'}
                             className='file-form__file-input'
@@ -53,10 +53,13 @@ FileForm.propTypes = {
 export default reduxForm({
     onSubmit: (values, dispatch, ownProps) => {
         if (ownProps.file === undefined) {
-            apiService.surveys.postFile(values.file[0], values.file[0].name)
-            .then(({ id }) => ownProps.onFileUploaded({ filename: values.file[0].name, id }))
-            .catch(() => toast(ownProps.vocab.ERROR.FILE_UPLOAD,
-                { type: 'error', autoClose: false }));
+            if (values.file) {
+                apiService.surveys.postFile(values.file[0], values.file[0].name)
+                .then(({ id }) => ownProps.onFileUploaded({ filename: values.file[0].name, id }))
+                .catch(() => toast(ownProps.vocab.ERROR.FILE_UPLOAD, { type: 'error', autoClose: false }));
+            } else {
+                toast(ownProps.vocab.ERROR.FILE_WARNING);
+            }
         } else {
             ownProps.onFileRemoved();
         }

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -84,9 +84,8 @@ class Questions extends Component {
                     <div className='questions__option-panel'>
                         <FileForm form={`file-form-${this.props.id}`}
                             vocab={this.props.vocab}
-                            disabled={this.props.displayMode}
+                            disabled={noValue || this.props.displayMode}
                             file={get(value, 'meta.file')}
-                            disabled={noValue}
                             onFileUploaded={(file) => {
                                 this.props.actions.upsertAnswer(
                                     this.props.assessmentId,


### PR DESCRIPTION
#### What does this PR do?
Always shows but disable the add file functions to Task Review until the user answers the question. Also adds a little bit of validation to stop the user from attempting to add a file before choosing it.

#### Related JIRA tickets:
INBA-756

#### How should this be manually tested?
Go to a user who is assigned a task with questions that they can add a file to.

Go to that question. Check that, if unanswered, the "Choose File" and "Add File" buttons are and appear disabled.

Answer the question. Verify the buttons become available and appear correct.

Attempt to "Add File" before choosing it. Verify you receive a toast explaining instructions on why that's not going to happen.

Choose a file. Click "Add File."

Verify that file is added, and display switches to "Remove File" with the file name beside it.

Remove file. Verify it works and "Choose File" prompts return. 

#### Background/Context
Bit of wonky styling because somehow the body grey text was overwriting both black and disabled gray text. I don't know why. Easy enough to back out of once we figure it out.

#### Screenshots (if appropriate):
