### PR TITLE
INBA-760 Default notifyLevel for Profile Submissions

### DIFF
--- a/src/common/actions/userActions.js
+++ b/src/common/actions/userActions.js
@@ -1,5 +1,5 @@
 import { toast } from 'react-toastify';
-
+import { get } from 'lodash';
 import apiService from '../../services/api';
 import * as actionTypes from '../actionTypes/userActionTypes';
 
@@ -26,7 +26,7 @@ export function getProfileSuccess(profile) {
 export function updateProfile(userData, errorMessages) {
     const requestBody = Object.assign({}, userData);
     if (typeof requestBody.notifyLevel !== 'number') {
-        requestBody.notifyLevel = userData.notifyLevel.value;
+        requestBody.notifyLevel = get(userData.notifyLevel, 'value', 2);
     }
     if (typeof requestBody.isActive !== 'boolean') {
         requestBody.isActive = userData.isActive.value;


### PR DESCRIPTION
#### What does this PR do?
Error was occurring because running scripts isn't giving a default value for notifyLevel in `Users`. Applying lodash get to the value and a backup default of 2 to solve issue. 

#### Related JIRA tickets:
INBA-760

#### How should this be manually tested?
Go into your DB and wipe out the 'notifyLevel' for a user. Login as that user and go to the profile page. Change something that isn't notify level. Save. Confirm save works and DB now has a value of '2' for notifyLevel.

Change notifyLevel and confirm it persists upon reloads, etc. 

#### Background/Context

#### Screenshots (if appropriate):
