### PR TITLE
Feature/inba 727 li recent messages

### DIFF
--- a/src/styles/dashboard/_message-list.scss
+++ b/src/styles/dashboard/_message-list.scss
@@ -66,7 +66,7 @@ $block-class: 'message-list';
         }
 
         &__subject {
-            flex: 3;
+            flex: 2;
             font-size: 15px;
             color: $title-color;
             white-space: nowrap;


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
Cleans up the recent messaging, increases the subject flex to prevent text from wrapping
#### Related JIRA tickets:
https://jira.amida-tech.com/secure/RapidBoard.jspa?rapidView=39&view=detail&selectedIssue=INBA-727&quickFilter=98
#### How should this be manually tested?
Go to the dashboard for any login and resize the page
Ensure that the text is switching to ellipsis and not stacking within the row.
Check that when the text in the 
#### Background/Context
The color  #333 is intentional. That is the new accessible safe colors and will replace $lead-font-color in a separate ticket.
 #### Screenshots (if appropriate):
