### PR TITLE
Feature/INBA-764 Optional callbacks

### DIFF
--- a/src/services/api/requests.js
+++ b/src/services/api/requests.js
@@ -56,8 +56,8 @@ export function apiGetRequest(fullURI, callback) {
             'Content-Type': 'application/json',
         },
     })
-    .then(handleResponse)
-    .then(res => callback(null, res), issue => callback(issue));
+    .then(callback ? handleResponse : handleResponseRejectWithResponse)
+    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
 }
 
 /**
@@ -68,7 +68,7 @@ export function apiGetRequest(fullURI, callback) {
  * @return {Any} handled by callback.
 * */
 export function apiPostRequest(fullURI, requestBody, callback) {
-    fetch(fullURI, {
+    return fetch(fullURI, {
         method: 'POST',
         headers: {
             Authorization: cookie.load('indaba-auth'),
@@ -77,8 +77,8 @@ export function apiPostRequest(fullURI, requestBody, callback) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(handleResponse)
-    .then(res => callback(null, res), issue => callback(issue));
+    .then(callback ? handleResponse : handleResponseRejectWithResponse)
+    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
 }
 
 /**
@@ -89,7 +89,7 @@ export function apiPostRequest(fullURI, requestBody, callback) {
  * @return {Any} handled by callback.
 * */
 export function apiPatchRequest(fullURI, requestBody, callback) {
-    fetch(fullURI, {
+    return fetch(fullURI, {
         method: 'PATCH',
         headers: {
             Authorization: cookie.load('indaba-auth'),
@@ -98,8 +98,8 @@ export function apiPatchRequest(fullURI, requestBody, callback) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(handleResponse)
-    .then(res => callback(null, res), issue => callback(issue));
+    .then(callback ? handleResponse : handleResponseRejectWithResponse)
+    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
 }
 
 /**
@@ -110,7 +110,7 @@ export function apiPatchRequest(fullURI, requestBody, callback) {
  * @return {Any} handled by callback.
 * */
 export function apiPutRequest(fullURI, requestBody, callback) {
-    fetch(fullURI, {
+    return fetch(fullURI, {
         method: 'PUT',
         headers: {
             Authorization: cookie.load('indaba-auth'),
@@ -119,8 +119,8 @@ export function apiPutRequest(fullURI, requestBody, callback) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(handleResponse)
-    .then(res => callback(null, res), issue => callback(issue));
+    .then(callback ? handleResponse : handleResponseRejectWithResponse)
+    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
 }
 
 /**
@@ -144,9 +144,9 @@ export function apiDeleteRequest(fullURI, requestBody, callback) {
         call.body = JSON.stringify(requestBody);
     }
 
-    fetch(fullURI, call)
-    .then(handleResponse)
-    .then(res => callback(null, res), issue => callback(issue));
+    return fetch(fullURI, call)
+    .then(callback ? handleResponse : handleResponseRejectWithResponse)
+    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
 }
 
 export function multipartFormDataPostRequest(fullURI, data) {


### PR DESCRIPTION
#### What does this PR do?
Adds support for Promise return values without breaking callback argument support.

If a callback is passed to a request method, there is no change in behavior for the caller: the callback is called after using the existing `handleResponse` function with `(err, response)` arguments.

If a callback is not passed, a modified handler (`handleResponseRejectWithResponse`) is used for the first promise transform, which includes the response object in a rejection in all non-ok network responses for the client to refer to in error handling. In this case, the `optionalCallback*` transforms pass the original result or rejection through to the client because the callback is absent.

This allows individual migration of calls to request methods by supporting callback and promise-based handling in the same call. Once all client code is updated to remove callbacks, the callback support will be removed

#### Related JIRA tickets:
[INBA-764](https://jira.amida-tech.com/browse/INBA-764)

#### How should this be manually tested?
Regression test all interactions with request methods. There should be no change in behavior of the application. All error handling in response to local and network failures are at risk and should be tested.

#### Background/Context

#### Screenshots (if appropriate):
