### PR TITLE
Feature/INBA-769 Thread in reverse chronological order

### DIFF
--- a/src/views/Messages/reducer.js
+++ b/src/views/Messages/reducer.js
@@ -65,7 +65,7 @@ export default (state = initialState, action) => {
     case actionTypes.GET_THREAD_SUCCESS:
         return update(state, {
             thread: { $set:
-                sortBy(action.thread, 'createdAt')
+                sortBy(action.thread, 'createdAt').reverse()
                 .map(transformServerMessageToReduxMessage),
             },
         });


### PR DESCRIPTION
#### What does this PR do?
Shows messages in a thread in reverse chronological order

#### Related JIRA tickets:
[INBA-769](https://jira.amida-tech.com/browse/INBA-769)

#### How should this be manually tested?
1. Generate a message thread
1. Load the messages thread
1. Check that the messages are in reverse chronological order: newest on top

#### Background/Context

#### Screenshots (if appropriate):
