### PR TITLE
Bug/INBA-817 Remove unassigned skip option

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -168,8 +168,6 @@
             "FORCE_PARAGRAPH": "Force complete to push the survey to the next stage. The person assigned to the next stage cannot start that task until its specified start date. To edit the start date of the next step, click on the date of the task cell.",
             "REASSIGN": "Reassign (Does not apply if task is force completed.)",
             "_CURRENTLY_ASSIGNED": " (Currently Assigned)",
-            "SKIP": "Skip stage and leave as unassigned.",
-            "SKIP_PARAGRAPH": "Skipping a stage will not affect the survey in any way. The task will be left as unassigned.",
             "NOTIFY": "Notify User. (User will receive default message unless changed.)",
             "_WILL_BE_NOTIFIED": " will be notified.",
             "NOTIFY_MESSAGE": "Your task has been forced to the next step. If you have questions, contact the project manager."

--- a/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsForm.js
+++ b/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsForm.js
@@ -33,16 +33,6 @@ class TaskOptionsForm extends Component {
                         type='select'
                         currentUser={this.props.currentUser}
                         userOptions={this.props.userOptions}/>
-                    <Field
-                        name='choice'
-                        component={TaskOptionsRadio}
-                        type='radio'
-                        value='skip'
-                        disabled={true}
-                        label={this.props.vocab.PROJECT.OPTIONS_MODAL.SKIP} />
-                    <div className='task-options-form__header-paragraph'>
-                        {this.props.vocab.PROJECT.OPTIONS_MODAL.SKIP_PARAGRAPH}
-                    </div>
                     <hr className='task-options-form__divider'/>
                     <Field
                         name='notify'


### PR DESCRIPTION
#### What does this PR do?
Removes the radio button for Skip task and leave as unassigned from the task options modal

#### Related JIRA tickets:
[INBA-817](https://jira.amida-tech.com/browse/INBA-817)

#### How should this be manually tested?
1. Open the task options modal for a task
1. Check that the Skip task and leave as unassigned option does not appear and that the other options work normally

#### Background/Context

#### Screenshots (if appropriate):
