### PR TITLE
Bug/INBA-790 Tall readonly comments

### DIFF
--- a/src/styles/taskreview/_flag-commentary.scss
+++ b/src/styles/taskreview/_flag-commentary.scss
@@ -9,10 +9,6 @@ $block-class:'flag-commentary';
             padding: 1em;
             background: #fff;
             font-size: 14px;
-
-            &--readonly {
-                height: 20em;
-            }
         }
 
         &__timestamp {


### PR DESCRIPTION
#### What does this PR do?
Fixes the very tall readonly comments by removing the css height declaration

#### Related JIRA tickets:
[INBA-790](https://jira.amida-tech.com/browse/INBA-790)

#### How should this be manually tested?
1. Open a task and add comments
1. Resolve the flags so that the task can be completed
1. Complete the task
1. Open the task again and check that the comments are as high as the content instead of being forced to `20em` height.

#### Background/Context

#### Screenshots (if appropriate):
