### PR TITLE
Bug/INBA-647 Stage settings background

### DIFF
--- a/src/styles/modals/stage/_stage-form.scss
+++ b/src/styles/modals/stage/_stage-form.scss
@@ -4,9 +4,7 @@ $block-class:'stage-form';
 @at-root {
     .#{$block-class} {
         color: $lead-font-color;
-        margin: 16px;
-        margin-bottom: 24px;
-        padding: 8px;
+        padding: 24px 24px 32px;
 
         &__input-field {
             border-radius: 2;


### PR DESCRIPTION
#### What does this PR do?
Prevents the background from bleeding through into the stage settings modal by using padding instead of margins

#### Related JIRA tickets:
[INBA-647](https://jira.amida-tech.com/browse/INBA-647)

#### How should this be manually tested?
1. Open a stage settings modal by clicking on a workflow matrix header
1. Check that the background doesn't bleed through between the modal title bar and the content

#### Background/Context

#### Screenshots (if appropriate):
