### PR TITLE
Bug/INBA-794 Delete assigned user groups in inactive projects

### DIFF
--- a/src/views/ProjectManagement/components/Users/PMUserGroupsTab.js
+++ b/src/views/ProjectManagement/components/Users/PMUserGroupsTab.js
@@ -26,7 +26,9 @@ class PMUserGroupsTab extends Component {
     }
     handleDeleteClick(userGroupId) {
         const dataState = this.getDataState(userGroupId);
-        if (dataState === STAGES) {
+        if (dataState === NO_STAGES) {
+            this.props.actions.pmShowUserGroupDeleteConfirmModal(userGroupId, dataState);
+        } else if (this.props.project.status === 1) {
             toast(this.props.vocab.ERROR.NO_DELETE_USER_GROUP_WITH_STAGES,
                 { autoClose: false, type: 'error' });
         } else {
@@ -53,7 +55,9 @@ class PMUserGroupsTab extends Component {
                     deleteModal &&
                     <Modal title={this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.TITLE}
                         bodyText={
-                            this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.DELETE_WITH_NOTHING
+                            deleteModal.dataState === NO_STAGES ?
+                            this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.DELETE_WITH_NOTHING :
+                            this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.DELETE_WITH_STAGES
                         }
                         onCancel={this.props.actions.pmHideUserGroupDeleteConfirmModal}
                         onSave={this.handleDeleteModalSave}


### PR DESCRIPTION
#### What does this PR do?
Allows the user to delete user groups that have been assigned to stages with the correct modal confirm message if the project is inactive

#### Related JIRA tickets:
[INBA-794](https://jira.amida-tech.com/browse/INBA-794)

#### How should this be manually tested?
1. Create a user group and assign it to a stage
1. Make the project inactive
1. Delete the user group
1. Check that a modal with the error messages from https://paper.dropbox.com/doc/Indaba-Conditional-Limits-ublG6ZqtvItRL1LL924Zd appears and that the delete is allowed after confirming

#### Background/Context
This allows the delete attempt on the front end but the back end fails to delete the group (after succeeding at removing the group members) due to a foreign key constraint:
```
{
  "!": 0,
  "e": "23503",
  "message": "update or delete on table \"Groups\" violates foreign key constraint \"WorkflowStepGroups_groupId_fkey\" on table \"WorkflowStepGroups\""
}
```
The group is, therefore, not actually deleted, but all members are removed, and the user sees this error message:
![image](https://user-images.githubusercontent.com/51333/37422738-4acaad4e-2792-11e8-85fe-d2764bf9725c.png)


#### Screenshots (if appropriate):
