### PR TITLE
INBA-812 & INBA-813/ Fix modal and override breaking grommet styles

### DIFF
--- a/src/styles/modals/_modal.scss
+++ b/src/styles/modals/_modal.scss
@@ -4,11 +4,17 @@ $header-footer: #f2f2f2;
 $block-class:'modal-c'; // Bootstrap is doing its crap again. Call this with a -c suffix then change later.
 
 @at-root {
+    .grommetux-layer .grommetux-layer__container {
+        display: block;
+        flex-direction: none;
+    }
+
     .#{$block-class} {
         margin: 4em 1em 1em;
         max-height: 100%;
         border: 1px solid $border-color;
         border-radius: 3px;
+        background-color: rgba(255, 255, 255, 1);
         box-shadow: 2px 0 6px 0 rgba(128, 134, 145, 0.6);
         // space at the top for positioning, space on the other side to show box-shadow
 
@@ -47,9 +53,9 @@ $block-class:'modal-c'; // Bootstrap is doing its crap again. Call this with a -
         }
 
         &__container {
-            background-color: #ffff;
+            background-color: #fff;
             border-bottom: 1px solid $border-color;
-            min-height: 100%;
+            height: 100%;
 
             // specific layers
             &.task-view-layer {


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
- Fixes the Modal transparency issue in Win10/IE11 environments
  - In IE11, Modals seem to show up slightly transparent enough to show what's beneath them and providing a visually distracting appearance
- Fixes the Modal height/scrollbar issue in Win10/IE11 environments
  - Likewise, in IE11, Modals seemed to show up slightly out of proportion such that they overflow the containing DOM element -- for whatever reason, IE11 did not like the `min-height` property (even though it should ignore it..: https://stackoverflow.com/questions/26596813/internet-explorer-doesnt-honor-my-min-height-100-with-flexbox), so I removed it entirely. Everything looked the same in Chrome, so hopefully this doesn't break in the other browsers.

#### Related JIRA tickets:
- https://jira.amida-tech.com/browse/INBA-812
- https://jira.amida-tech.com/browse/INBA-813

#### How should this be manually tested?
>Through browserstack or a Windows 10 machine:
- Log in and trigger any Modal event to display a Modal
- Ensure the transparency issue is no longer there (INBA-812)
- Ensure the height issue (and scrollbars) are no longer there (INBA-813)
- Ensure these changes don't break in other browsers (Firefox, Chrome, Safari, etc)

#### Background/Context

#### Screenshots (if appropriate):
