### PR TITLE
Feature/INBA-880 Remove callback support

### DIFF
--- a/src/services/api/requests.js
+++ b/src/services/api/requests.js
@@ -19,8 +19,6 @@ export function addQueryParams(url, params) {
  * Executes a POST request on the given URI
  * @param {String} fullURI
  * @param {Object} requestBody
- * @param {Function} callback
- * @return {Any} handled by callback.
 * */
 export function apiAuthPostRequest(fullURI, requestBodyObject) {
     const encodedRequestBodyObject = formurlencoded(requestBodyObject);
@@ -36,18 +34,11 @@ export function apiAuthPostRequest(fullURI, requestBodyObject) {
     .then(handleResponse);
 }
 
-const optionalCallbackSuccess = callback => response =>
-    (callback ? callback(null, response) : response);
-const optionalCallbackError = callback => response =>
-    (callback ? callback(response) : Promise.reject(response));
-
 /**
  * Executes a GET request on the given URI
  * @param {String} fullURI
- * @param {Function} callback
- * @return {Any} handled by callback. Generally the response data.
 * */
-export function apiGetRequest(fullURI, callback) {
+export function apiGetRequest(fullURI) {
     return fetch(fullURI, {
         method: 'GET',
         headers: {
@@ -58,18 +49,15 @@ export function apiGetRequest(fullURI, callback) {
             Pragma: 'no-cache',
         },
     })
-    .then(callback ? handleResponse : handleResponseRejectWithResponse)
-    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
+    .then(handleResponse);
 }
 
 /**
  * Executes a POST request on the given URI
  * @param {String} fullURI
  * @param {Object} requestBody
- * @param {Function} callback
- * @return {Any} handled by callback.
 * */
-export function apiPostRequest(fullURI, requestBody, callback) {
+export function apiPostRequest(fullURI, requestBody) {
     return fetch(fullURI, {
         method: 'POST',
         headers: {
@@ -79,18 +67,15 @@ export function apiPostRequest(fullURI, requestBody, callback) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(callback ? handleResponse : handleResponseRejectWithResponse)
-    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
+    .then(handleResponse);
 }
 
 /**
  * Executes a PATCH request on the given URI
  * @param {String} fullURI
  * @param {Object} requestBody
- * @param {Function} callback
- * @return {Any} handled by callback.
 * */
-export function apiPatchRequest(fullURI, requestBody, callback) {
+export function apiPatchRequest(fullURI, requestBody) {
     return fetch(fullURI, {
         method: 'PATCH',
         headers: {
@@ -100,18 +85,15 @@ export function apiPatchRequest(fullURI, requestBody, callback) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(callback ? handleResponse : handleResponseRejectWithResponse)
-    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
+    .then(handleResponse);
 }
 
 /**
  * Executes a PUT request on the given URI
  * @param {String} fullURI
  * @param {Object} requestBody
- * @param {Function} callback
- * @return {Any} handled by callback.
 * */
-export function apiPutRequest(fullURI, requestBody, callback) {
+export function apiPutRequest(fullURI, requestBody) {
     return fetch(fullURI, {
         method: 'PUT',
         headers: {
@@ -121,18 +103,15 @@ export function apiPutRequest(fullURI, requestBody, callback) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(callback ? handleResponse : handleResponseRejectWithResponse)
-    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
+    .then(handleResponse);
 }
 
 /**
  * Executes a DELETE request on the given URI
  * @param {String} fullURI
  * @param {Object} requestBody
- * @param {Function} callback
- * @return {Any} handled by callback.
 * */
-export function apiDeleteRequest(fullURI, requestBody, callback) {
+export function apiDeleteRequest(fullURI, requestBody) {
     const call = {
         method: 'DELETE',
         headers: {
@@ -146,9 +125,7 @@ export function apiDeleteRequest(fullURI, requestBody, callback) {
         call.body = JSON.stringify(requestBody);
     }
 
-    return fetch(fullURI, call)
-    .then(callback ? handleResponse : handleResponseRejectWithResponse)
-    .then(optionalCallbackSuccess(callback), optionalCallbackError(callback));
+    return fetch(fullURI, call).then(handleResponse);
 }
 
 export function multipartFormDataPostRequest(fullURI, data) {
@@ -183,22 +160,6 @@ export function putObjectRequest(file, fullURI) {
 // ////////////////
 
 function handleResponse(response) {
-    if (response.ok) {
-        return decodeResponse(response);
-    }
-    return decodeResponse(response).then((body) => {
-        // reject with a normalized error structure that includes the original
-        // response object and the decoded body
-        // currently only for 401 so the auth middleware can detect it without
-        // having to change every other error handler that just expects the body
-        if (response.status === 401) {
-            return Promise.reject({ response, body });
-        }
-        return Promise.reject(body);
-    });
-}
-
-function handleResponseRejectWithResponse(response) {
     if (response.ok) {
         return decodeResponse(response);
     }


### PR DESCRIPTION
#### What does this PR do?
This PR just removes the scaffolding that allowed both callbacks and promise handling in the request methods.
Any client code that passed callbacks have already been migrated, and this removes the old support for them.

#### Related JIRA tickets:
[INBA-880](https://jira.amida-tech.com/browse/INBA-880)

#### How should this be manually tested?
Check for no change in behavior across the application. This PR effects any code that makes a network request (which is a lot). In particular, ALL rejected promises from request calls now include the response object itself in addition to the parsed body of the network response. All client code that handled these rejects should already have been migrated in previous promise migrations tickets. But you should double check because these are exceptional cases by nature. Any code that is calling a request and `.catch`es should be checked

#### Background/Context

#### Screenshots (if appropriate):
