### PR TITLE
INBA-738 / Replace Object.value with Object.keys map loop through entries

### DIFF
--- a/src/common/components/Dashboard/Stamp.js
+++ b/src/common/components/Dashboard/Stamp.js
@@ -33,7 +33,9 @@ class Stamp extends Component {
 Stamp.propTypes = {
     label: PropTypes.string.isRequired,
     value: PropTypes.number.isRequired,
-    type: PropTypes.oneOf(Object.values(StampType)),
+    // TODO: Should this be required?
+    type: PropTypes.oneOf(Object.keys(StampType)
+        .map(entry => StampType[entry])),
 };
 
 Stamp.defaultProps = {

--- a/src/common/components/StatusLabel.js
+++ b/src/common/components/StatusLabel.js
@@ -17,7 +17,8 @@ const StatusLabel = ({ label, type }) =>
     <div className={`status-label status-label--${_modifiers[type]}`}>{label}</div>;
 
 StatusLabel.propTypes = {
-    type: PropTypes.oneOf(Object.values(StatusLabelType)).isRequired,
+    type: PropTypes.oneOf(Object.keys(StatusLabelType)
+        .map(entry => StatusLabelType[entry])).isRequired,
     label: PropTypes.string.isRequired,
 };
 


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
- Replaces `Object.value()` (which may not work in certain browsers) with a "purer" ES6 implementation that loops through the map and searches for the entry.

#### Related JIRA tickets:
- https://jira.amida-tech.com/browse/INBA-738

#### How should this be manually tested?
- Research must be done in order to identify which browsers do not natively support `Object.value()` and then test these Indaba-Client components within them (BrowserStack should help)
- There are only two components, but I am not sure of their locations yet (will update with a comment)

#### Background/Context

#### Screenshots (if appropriate):
