### PR TITLE
INBA-807 / Section Name, error message if no name

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -98,6 +98,7 @@
         "SECTION_MINIMUM": "Each survey must have a minimum of one section.",
         "EMPTY_TEXT": "Please enter text into the field.",
         "BLANKS": "There are unfilled questions or options in the question list. Please give them a value or delete them.",
+        "BLANK_SECTION": "The are unfilled section names. Please give them a value or delete them.",
         "DISAGREE_COMMENTS": "All other responses have been recorded, but please disagree and provide a comment for the following questions: ",
         "DATA_REQUEST": "There has been a problem with downloading your data.",
         "COMING_SOON": "Coming soon."
@@ -182,7 +183,6 @@
         "SURVEY": "Survey",
         "TITLE": "Title",
         "SUBJECT": "Subject",
-        "PROJECT_TITLE": "Project Title",
         "SURVEY_TITLE": "Survey Title",
         "SUBJECT_NAME": "Subject Name",
         "STATUS": "Status",
@@ -406,6 +406,7 @@
         "SUBMIT_INSTRUCTIONS_3":" and finish later. All progress will be saved.",
         "REVIEW_INSTRUCTIONS": "Click 'Save Review Progress' if you wish to commit your comments.",
         "NAME_OPTIONAL": " Name (Optional)",
+        "NAME": " Name",
         "USER_ENTERS": "Enter your answer here.",
         "BP_ENTERS": "And a new text field will appear here.",
         "NUM_ENTER": "Number goes here.",

--- a/src/views/SurveyBuilder/components/CreateSectionPanel.js
+++ b/src/views/SurveyBuilder/components/CreateSectionPanel.js
@@ -15,7 +15,7 @@ class CreateSectionPanel extends Component {
                         type='text'
                         defaultValue={this.props.section.name}
                         placeholder={this.props.vocab.SURVEY.SECTION_ +
-                            (this.props.sectionIndex + 1) + this.props.vocab.SURVEY.NAME_OPTIONAL}
+                            (this.props.sectionIndex + 1) + this.props.vocab.SURVEY.NAME}
                         onChange={event => this.props.actions.updateSection(
                             this.props.sectionIndex, event.target.value)} />
                     <button className='create-section-panel__menu-button'

--- a/src/views/SurveyBuilder/components/CreateSurveyPanel.js
+++ b/src/views/SurveyBuilder/components/CreateSurveyPanel.js
@@ -54,17 +54,15 @@ class CreateSurveyPanel extends Component {
                                     });
                                 });
                                 const blankSection = some(this.props.form.sections, (section) => {
-                                    return some(section.name, (secName) => {
-                                        return (secName.text.match(/^\s*$/) !== null);
-                                    });
+                                    return (section.name.match(/^\s*$/) !== null);
                                 });
                                 if (blanks) {
                                     toast(this.props.vocab.ERROR.BLANKS);
                                 }
-                                if (!blankSection) {
+                                if (blankSection) {
                                     toast(this.props.vocab.ERROR.BLANK_SECTION);
                                 }
-                                if (!blanks && blankSection) {
+                                if (!blanks && !blankSection) {
                                     this.props.actions.patchSurvey(
                                         this.props.form,
                                         this.props.vocab.SURVEY.SUCCESS,

--- a/src/views/SurveyBuilder/components/CreateSurveyPanel.js
+++ b/src/views/SurveyBuilder/components/CreateSurveyPanel.js
@@ -12,87 +12,95 @@ class CreateSurveyPanel extends Component {
         return (
             <div className='create-survey-panel'>
                 {this.props.ui.showSectionDeleteConfirmModal > -1 &&
-                    <Modal title={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.TITLE}
-                        bodyText={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.DELETE_WARNING}
-                        onCancel={() => this.props.actions.showSectionDeleteConfirmModal(-1)}
-                        onSave={() => {
-                            this.props.actions.deleteSection(
-                                this.props.ui.showSectionDeleteConfirmModal);
-                            this.props.actions.showSectionDeleteConfirmModal(-1);
-                        }}
-                        saveLabel={this.props.vocab.COMMON.DELETE}/>}
+                <Modal title={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.TITLE}
+                       bodyText={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.DELETE_WARNING}
+                       onCancel={() => this.props.actions.showSectionDeleteConfirmModal(-1)}
+                       onSave={() => {
+                           this.props.actions.deleteSection(
+                               this.props.ui.showSectionDeleteConfirmModal);
+                           this.props.actions.showSectionDeleteConfirmModal(-1);
+                       }}
+                       saveLabel={this.props.vocab.COMMON.DELETE}/>}
                 <div className='create-survey-panel__view-controls'>
                     <Select className='create-survey-panel__view-select'
-                        options={this.props.options}
-                        value={this.props.ui.sectionView}
-                        clearable={false}
-                        disabled={this.props.options.length === 1}
-                        onChange={event => this.props.actions.changeSectionView(event.value)}/>
+                            options={this.props.options}
+                            value={this.props.ui.sectionView}
+                            clearable={false}
+                            disabled={this.props.options.length === 1}
+                            onChange={event => this.props.actions.changeSectionView(event.value)}/>
                     <div className='create-survey-panel__accordion-buttons'>
                         <button className='create-survey-panel__button-expand'
-                            onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
-                                {this.props.vocab.PROJECT.EXPAND_ALL}
-                            </button>
+                                onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
+                            {this.props.vocab.PROJECT.EXPAND_ALL}
+                        </button>
                         <button className='create-survey-panel__button-collapse'
-                            onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
-                                {this.props.vocab.PROJECT.COLLAPSE_ALL}
+                                onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
+                            {this.props.vocab.PROJECT.COLLAPSE_ALL}
                         </button>
                     </div>
                 </div>
                 <div className='create-survey-panel__survey-controls'>
                     <button className='create-survey-panel__survey-save'
-                        onClick={() => {
-                            const blanks = some(this.props.form.sections, (section) => {
-                                return some(section.questions, (question) => {
-                                    if (question.text.match(/^\s*$/) !== null) {
-                                        return true;
-                                    }
-                                    if (has(question, 'choices')) {
-                                        return some(question.choices, choice => choice.text.match(/^\s*$/) !== null);
-                                    }
-                                    return false;
+                            onClick={() => {
+                                const blanks = some(this.props.form.sections, (section) => {
+                                    return some(section.questions, (question) => {
+                                        if (question.text.match(/^\s*$/) !== null) {
+                                            return true;
+                                        }
+                                        if (has(question, 'choices')) {
+                                            return some(question.choices, choice => choice.text.match(/^\s*$/) !== null);
+                                        }
+                                        return false;
+                                    });
                                 });
-                            });
-                            if (blanks) {
-                                toast(this.props.vocab.ERROR.BLANKS);
-                            } else {
-                                this.props.actions.patchSurvey(
-                                    this.props.form,
-                                    this.props.vocab.SURVEY.SUCCESS,
-                                    this.props.vocab.ERROR);
-                            }
-                        }
-                    }>
+                                const blankSection = some(this.props.form.sections, (section) => {
+                                    return some(section.name, (secName) => {
+                                        return (secName.text.match(/^\s*$/) !== null);
+                                    });
+                                });
+                                if (blanks) {
+                                    toast(this.props.vocab.ERROR.BLANKS);
+                                }
+                                if (!blankSection) {
+                                    toast(this.props.vocab.ERROR.BLANK_SECTION);
+                                }
+                                if (!blanks && blankSection) {
+                                    this.props.actions.patchSurvey(
+                                        this.props.form,
+                                        this.props.vocab.SURVEY.SUCCESS,
+                                        this.props.vocab.ERROR);
+                                }
+                            }}>
                         {this.props.vocab.SURVEY.SAVE_PROGRESS}
                     </button>
                 </div>
-                    <div className='create-survey-panel__instructions'>
-                        {this.props.vocab.PROJECT.INSTRUCTIONS}
-                        <textarea className='create-survey-panel__instructions-entry'
-                            placeholder={this.props.vocab.SURVEY.ENTER_INSTRUCTIONS}
-                            value={this.props.form.description}
-                            onChange={event =>
-                                this.props.actions.updateInstructions(event.target.value)} />
-                    </div>
+                <div className='create-survey-panel__instructions'>
+                    {this.props.vocab.PROJECT.INSTRUCTIONS}
+                    <textarea className='create-survey-panel__instructions-entry'
+                              placeholder={this.props.vocab.SURVEY.ENTER_INSTRUCTIONS}
+                              value={this.props.form.description}
+                              onChange={event =>
+                                  this.props.actions.updateInstructions(event.target.value)}/>
+                </div>
                 <div className='create-survey-panel__sections-list'>
-                {this.props.ui.sectionView === -1 ?
-                    this.props.form.sections.map((section, sectionIndex) => (
+                    {this.props.ui.sectionView === -1 ?
+                        this.props.form.sections.map((section, sectionIndex) => (
+                            <CreateSectionPanel
+                                key={`key-section-${sectionIndex}`}
+                                ui={this.props.ui}
+                                section={section}
+                                sectionIndex={sectionIndex}
+                                sectionLength={this.props.form.sections.length}
+                                actions={this.props.actions}
+                                vocab={this.props.vocab}/>
+                        )) :
                         <CreateSectionPanel
-                            key={`key-section-${sectionIndex}`}
                             ui={this.props.ui}
-                            section={section}
-                            sectionIndex={sectionIndex}
+                            section={this.props.form.sections[this.props.ui.sectionView]}
+                            sectionIndex={this.props.ui.sectionView}
                             sectionLength={this.props.form.sections.length}
                             actions={this.props.actions}
-                            vocab={this.props.vocab} />
-                    )) :
-                    <CreateSectionPanel
-                        ui={this.props.ui}
-                        section={this.props.form.sections[this.props.ui.sectionView]}
-                        sectionIndex={this.props.ui.sectionView}
-                        sectionLength={this.props.form.sections.length}
-                        actions={this.props.actions}
-                        vocab={this.props.vocab} />}
+                            vocab={this.props.vocab}/>}
                 </div>
             </div>
         );


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
Fixes save survey so that it checks for section names. If they are not filled the site throws an error. 

#### Related JIRA tickets:
https://jira.amida-tech.com/browse/INBA-807

#### How should this be manually tested?
try deleting section names to see if the error is there. 
try saving successfully

#### Background/Context

#### Screenshots (if appropriate):
<img width="755" alt="screen shot 2018-06-22 at 4 54 13 pm" src="https://user-images.githubusercontent.com/15223252/41869479-1d59ed16-7887-11e8-8093-60720d13419d.png">