### PR TITLE
Fix/INBA-802 add file without "add file" button

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -177,7 +177,6 @@
             "NOTIFY_MESSAGE": "Your task has been forced to the next step. If you have questions, contact the project manager."
         },
         "PROJECT": "Project",
-        "PROJECT_TITLE": "Project Title",
         "PROJECTS": "Projects",
         "SURVEY": "Survey",
         "TITLE": "Title",
@@ -384,7 +383,6 @@
         "DELETE_QUESTION": "Delete Question",
         "SELECT_FILE": "Select a file",
         "NO_FILE": "No file chosen",
-        "ADD_FILE": "Add File",
         "REMOVE_FILE": "Remove File",
         "FILE_NAME_PLACEHOLDER": "File name",
         "ADD_LINK": "Add Link",

--- a/src/styles/taskreview/_file-form.scss
+++ b/src/styles/taskreview/_file-form.scss
@@ -24,10 +24,6 @@ $block-class: 'file-form';
                 margin-left: 8px;
             }
 
-            &--add {
-                margin-top: 4px;
-            }
-
             &:disabled {
                 color: graytext;
             }

--- a/src/views/TaskReview/components/Questions/FileForm.js
+++ b/src/views/TaskReview/components/Questions/FileForm.js
@@ -10,19 +10,14 @@ class FileForm extends Component {
     render() {
         return (
             <form className='file-form'
-                onSubmit={this.props.handleSubmit}>
+                  onSubmit={this.props.handleSubmit}>
                 {
                     this.props.file === undefined &&
                     <div className='file-form__add-form'>
                         <Field name={'file'}
-                            className='file-form__file-input'
-                            disabled={this.props.disabled}
-                            component={ReduxFormFileInput}/>
-                        <button className='file-form__submit file-form__submit--add'
-                            type='submit'
-                            disabled={this.props.disabled}>
-                            {this.props.vocab.SURVEY.ADD_FILE}
-                        </button>
+                               className='file-form__file-input'
+                               disabled={this.props.disabled}
+                               component={ReduxFormFileInput}/>
                     </div>
                 }
                 {
@@ -51,18 +46,22 @@ FileForm.propTypes = {
 };
 
 export default reduxForm({
-    onSubmit: (values, dispatch, ownProps) => {
+    onChange: (values, dispatch, ownProps) => {
         if (ownProps.file === undefined) {
             if (values.file) {
                 // Upload File to AWS and File name to survey service
                 apiService.projects.postFileToAws(values.file[0])
-                .then(ownProps.onFileUploaded)
-                .catch(() => toast(ownProps.vocab.ERROR.FILE_UPLOAD, { type: 'error', autoClose: false }));
+                    .then(ownProps.onFileUploaded)
+                    .catch(() => toast(ownProps.vocab.ERROR.FILE_UPLOAD, { type: 'error', autoClose: false }));
             } else {
                 toast(ownProps.vocab.ERROR.FILE_WARNING);
             }
-        } else {
+        }
+    },
+    onSubmit: (values, dispatch, ownProps) => {
+        if (ownProps.file !== undefined) {
             ownProps.onFileRemoved();
         }
     },
 })(FileForm);
+


### PR DESCRIPTION
If this PR fixes a bug, you _must_ add test cases representative of the bug.

Please refer to [Tettra](https://app.tettra.co/teams/amida/pages/amida-pull-request-and-code-review-guide) for PR review guidelines.

#### What does this PR do?
When a user is filling out a survey, currently they have to select the file and then also click the "Add file" button. This is causing problems, and we should instead upload the file as soon as the user had selected the file to be uploaded on the file picker. 

#### Related JIRA tickets:
INBA-802

#### How should this be manually tested?
Take a survey that has a question that includes adding a file. 
The file should automatically upload, save and then ask to remove it. 
Save file and download to make sure it works properly. 

#### Background/Context
follows other common file attachment patterns.

#### Screenshots (if appropriate):