### PR TITLE
Update for messaging var in .env.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 API_URL=http://localhost:3005
 AUTH_API_URL=http://localhost:4000/api/v1
 SURVEY_API_URL=http://localhost:9005/api/v1.0
-MESSAGING_API_URL=http://localhost:4002/api
+MESSAGING_API_URL=http://localhost:4002/api/v1
 SYS_MESSAGE_USER=indaba@example.com
 REALM=testorg

--- a/src/config/development.js
+++ b/src/config/development.js
@@ -6,7 +6,7 @@ export default {
 
     SURVEY_API_URL: process.env.SURVEY_API_URL || 'http://localhost:9005/api/v1.0',
 
-    MESSAGING_API_URL: process.env.MESSAGING_API_URL || 'http://localhost:4002/api',
+    MESSAGING_API_URL: process.env.MESSAGING_API_URL || 'http://localhost:4002/api/v1',
 
     REALM: process.env.REALM || 'testorg',
 


### PR DESCRIPTION
*Heads up!* You need to update the `MESSAGING_API_URL` in your indaba-client's `.env` (if you're using one) to have `/api/v1` at the end.