### PR TITLE
Updates to allow manual tree-shaking

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,4 +1,12 @@
 
+# enable gzip compression
+gzip on;
+gzip_min_length  1100;
+gzip_buffers  4 32k;
+gzip_types    text/html text/plain application/javascript application/x-javascript text/xml text/css;
+gzip_vary on;
+# end gzip configuration
+
 server {
   root   /usr/share/nginx/html/;
   index  index.html;

--- a/src/common/actions/navActions.js
+++ b/src/common/actions/navActions.js
@@ -23,19 +23,17 @@ export function checkProtection(profile) {
 }
 
 export function checkRefresh() {
-    return dispatch => new Promise(resolve =>
-        apiService.auth.requestRefreshToken(
-              cookie.load('indaba-username'),
-              cookie.load('indaba-refresh'),
-          ).then((refreshResp) => {
-              cookie.save('indaba-auth', `Bearer ${refreshResp.token}`, { path: '/' });
-              cookie.save('indaba-expire', Date.now() + (refreshResp.ttl * 1000), { path: '/' });
-              dispatch(_refreshTokenSuccess());
-              return resolve();
-          }).catch(() => {
-              logOut('');
-          }),
-    );
+    return dispatch => new Promise(resolve => apiService.auth.requestRefreshToken(
+        cookie.load('indaba-username'),
+        cookie.load('indaba-refresh'),
+    ).then((refreshResp) => {
+        cookie.save('indaba-auth', `Bearer ${refreshResp.token}`, { path: '/' });
+        cookie.save('indaba-expire', Date.now() + (refreshResp.ttl * 1000), { path: '/' });
+        dispatch(_refreshTokenSuccess());
+        return resolve();
+    }).catch(() => {
+        logOut('');
+    }));
 }
 
 export function toggleCheckBackend() {

--- a/src/common/actions/projectActions.js
+++ b/src/common/actions/projectActions.js
@@ -8,8 +8,7 @@ import Time from '../../utils/Time';
 import apiService from '../../services/api';
 
 export function getProjects(errorMessages) {
-    return dispatch =>
-        apiService.projects.getProjects()
+    return dispatch => apiService.projects.getProjects()
         .then((projectResp) => {
             dispatch(getSurveys(errorMessages));
             dispatch(_getProjectsSuccess(projectResp));
@@ -22,8 +21,7 @@ export function getProjects(errorMessages) {
 }
 
 export function postProject(requestBody, errorMessages) {
-    return dispatch =>
-        apiService.projects.postProject(requestBody)
+    return dispatch => apiService.projects.postProject(requestBody)
         .then((projectResp) => {
             dispatch(_postProjectSuccess(projectResp));
             return projectResp;
@@ -37,8 +35,7 @@ export function postProject(requestBody, errorMessages) {
 export function putProject(project, errorMessages) {
     const { status, name: codeName } = project;
 
-    return dispatch =>
-        apiService.projects.putProject(project.id, { status, codeName })
+    return dispatch => apiService.projects.putProject(project.id, { status, codeName })
         .then(() => dispatch(getProjectById(project.id, false, errorMessages)))
         .catch((projectErr) => {
             dispatch(_reportProjectError(projectErr, errorMessages.PROJECT_REQUEST));
@@ -47,8 +44,7 @@ export function putProject(project, errorMessages) {
 }
 
 export function getProjectById(projectId, getTasks, errorMessages) {
-    return dispatch =>
-        apiService.projects.getProjectById(projectId)
+    return dispatch => apiService.projects.getProjectById(projectId)
         .then((projectResp) => {
             if (projectResp.surveyId) {
                 dispatch(getSurveyById(projectResp.surveyId, errorMessages));
@@ -81,14 +77,12 @@ export function putStage(project, stage, fromWizard, errorMessages) {
             role: 3,
             startDate: stage.startDate,
             endDate: stage.endDate,
-        },
-    )];
+        })];
     if (typeof requestBody[0].endDate === 'object') {
         requestBody[0].endDate.setHours(23, 59, 59, 999);
     }
 
-    return dispatch =>
-        apiService.projects.putWorkflowSteps(project.workflowId, requestBody)
+    return dispatch => apiService.projects.putWorkflowSteps(project.workflowId, requestBody)
         .then((stepResp) => {
             if (!fromWizard && !project.subjects.length) {
                 toast(errorMessages.SUBJECT_NEED);
@@ -97,7 +91,8 @@ export function putStage(project, stage, fromWizard, errorMessages) {
             }
             const id = stepResp.inserted[0] ? stepResp.inserted[0] : stepResp.updated[0];
             dispatch(_putStageSuccess(
-                        Object.assign({}, requestBody[0], { id }), project.id));
+                Object.assign({}, requestBody[0], { id }), project.id,
+            ));
             return stepResp;
         })
         .catch((stepErr) => {
@@ -107,8 +102,7 @@ export function putStage(project, stage, fromWizard, errorMessages) {
 }
 
 export function deleteStage(projectId, stageId) {
-    return dispatch =>
-        apiService.projects.deleteWorkflowStep(stageId)
+    return dispatch => apiService.projects.deleteWorkflowStep(stageId)
         .then(() => {
             dispatch(getProjectById(projectId));
         });
@@ -121,8 +115,7 @@ export function addSubject(project, subjects, fromWizard, errorMessages) {
         productId: project.productId,
     };
 
-    return dispatch =>
-        apiService.projects.postUOA(requestBody)
+    return dispatch => apiService.projects.postUOA(requestBody)
         .then((uoaResp) => {
             if (!fromWizard && !project.stages.length) {
                 toast(errorMessages.STAGE_NEED);
@@ -142,8 +135,7 @@ export function deleteSubject(project, uoaId, fromWizard, errorMessages) {
         uoaId,
     };
 
-    return dispatch =>
-        apiService.projects.deleteUOA(uoaId, requestBody)
+    return dispatch => apiService.projects.deleteUOA(uoaId, requestBody)
         .then((uoaResp) => {
             dispatch(_deleteSubjectSuccess(uoaId, project.id));
             return uoaResp;
@@ -160,8 +152,7 @@ export function addUser(userId, projectId, errorMessages) {
         projectId,
     };
 
-    return dispatch =>
-        apiService.projects.postProjectUsers(projectId, requestBody)
+    return dispatch => apiService.projects.postProjectUsers(projectId, requestBody)
         .then((userResponse) => {
             dispatch(_postProjectUserSuccess(userId, projectId));
             return userResponse;
@@ -175,8 +166,7 @@ export function addUser(userId, projectId, errorMessages) {
 export function removeUser(userId, projectId, errorMessages) {
     // TODO: Do safety call for tasks assigned to this user.
 
-    return dispatch =>
-        apiService.projects.deleteProjectUsers(projectId, userId)
+    return dispatch => apiService.projects.deleteProjectUsers(projectId, userId)
         .then((userResponse) => {
             dispatch(_deleteProjectUserSuccess(userId, projectId));
             return userResponse;
@@ -195,8 +185,7 @@ export function addUserGroup(groupData, projectId, organizationId, errorMessages
         users: groupData.users,
         projectId,
     };
-    return dispatch =>
-        apiService.projects.postGroup(organizationId, requestBody)
+    return dispatch => apiService.projects.postGroup(organizationId, requestBody)
         .then((groupResp) => {
             dispatch(getProjectById(projectId, errorMessages));
             dispatch(getUsers(errorMessages));
@@ -211,8 +200,7 @@ export function addUserGroup(groupData, projectId, organizationId, errorMessages
 export function updateUserGroup(groupId, groupData, projectId, organizationId, errorMessages) {
     const { title, users: userId } = groupData;
 
-    return dispatch =>
-        apiService.projects.putGroup(groupId, { title, userId, organizationId })
+    return dispatch => apiService.projects.putGroup(groupId, { title, userId, organizationId })
         .then((groupResp) => {
             dispatch(getProjectById(projectId, errorMessages));
             dispatch(getUsers(errorMessages));
@@ -225,8 +213,7 @@ export function updateUserGroup(groupId, groupData, projectId, organizationId, e
 }
 
 export function exportData(productId, projectName, errorMessages) {
-    return dispatch =>
-        apiService.projects.exportData(productId)
+    return dispatch => apiService.projects.exportData(productId)
         .then((dataResp) => {
             const blob = new Blob([_stringToBytes(dataResp)], { type: 'application/zip' });
             if (window.navigator.msSaveOrOpenBlob) {

--- a/src/common/actions/surveyActions.js
+++ b/src/common/actions/surveyActions.js
@@ -9,14 +9,14 @@ import { updateProjectWithSurvey } from './projectActions';
 export function getSurveys(errorMessages) {
     return (dispatch) => {
         apiService.surveys.getSurveys()
-        .then((surveyResp) => {
-            dispatch(_getSurveysSuccess(surveyResp));
-            return surveyResp;
-        })
-        .catch((surveyErr) => {
-            dispatch(_reportSurveyError(surveyErr, errorMessages.FETCH_SURVEYS));
-            throw surveyErr;
-        });
+            .then((surveyResp) => {
+                dispatch(_getSurveysSuccess(surveyResp));
+                return surveyResp;
+            })
+            .catch((surveyErr) => {
+                dispatch(_reportSurveyError(surveyErr, errorMessages.FETCH_SURVEYS));
+                throw surveyErr;
+            });
     };
 }
 
@@ -28,21 +28,21 @@ export function postSurvey(survey, project, errorMessages) {
     };
     return (dispatch) => {
         apiService.surveys.postSurvey(requestBody)
-        .then((surveyResp) => {
-            const updateBody = {
-                id: project.productId,
-                surveyId: surveyResp.id,
-            };
-            return apiService.projects.putSurveyToProduct(project.productId, updateBody)
-            .then(() => {
-                dispatch(_postSurveySuccess(Object.assign({}, survey, surveyResp)));
-                dispatch(updateProjectWithSurvey(project.id, surveyResp.id));
+            .then((surveyResp) => {
+                const updateBody = {
+                    id: project.productId,
+                    surveyId: surveyResp.id,
+                };
+                return apiService.projects.putSurveyToProduct(project.productId, updateBody)
+                    .then(() => {
+                        dispatch(_postSurveySuccess(Object.assign({}, survey, surveyResp)));
+                        dispatch(updateProjectWithSurvey(project.id, surveyResp.id));
+                    });
+            })
+            .catch((surveyErr) => {
+                dispatch(_reportSurveyError(surveyErr, errorMessages.SURVEY_REQUEST));
+                throw surveyErr;
             });
-        })
-        .catch((surveyErr) => {
-            dispatch(_reportSurveyError(surveyErr, errorMessages.SURVEY_REQUEST));
-            throw surveyErr;
-        });
     };
 }
 
@@ -57,30 +57,30 @@ export function patchSurvey(survey, successMessage, errorMessages) {
 
     return (dispatch) => {
         apiService.surveys.patchSurvey(survey.id, requestBody)
-        .then((surveyResp) => {
-            dispatch(_patchSurveySuccess(survey.id, requestBody));
-            toast(successMessage);
-            apiService.projects.editSurvey(survey.id);
-            return surveyResp;
-        })
-        .catch((surveyErr) => {
-            dispatch(_reportSurveyError(surveyErr, errorMessages.FETCH_SURVEYS));
-            throw surveyErr;
-        });
+            .then((surveyResp) => {
+                dispatch(_patchSurveySuccess(survey.id, requestBody));
+                toast(successMessage);
+                apiService.projects.editSurvey(survey.id);
+                return surveyResp;
+            })
+            .catch((surveyErr) => {
+                dispatch(_reportSurveyError(surveyErr, errorMessages.FETCH_SURVEYS));
+                throw surveyErr;
+            });
     };
 }
 
 export function getSurveyById(surveyId, errorMessages) {
     return (dispatch) => {
         apiService.surveys.getSurveyById(surveyId)
-        .then((surveyResp) => {
-            dispatch(_getSurveyByIdSuccess(surveyResp.id, surveyResp));
-            return surveyResp;
-        })
-        .catch((surveyErr) => {
-            dispatch(_reportSurveyError(surveyErr, errorMessages.FETCH_SURVEYS));
-            throw surveyErr;
-        });
+            .then((surveyResp) => {
+                dispatch(_getSurveyByIdSuccess(surveyResp.id, surveyResp));
+                return surveyResp;
+            })
+            .catch((surveyErr) => {
+                dispatch(_reportSurveyError(surveyErr, errorMessages.FETCH_SURVEYS));
+                throw surveyErr;
+            });
     };
 }
 
@@ -91,15 +91,14 @@ export function completeAssessment(assessmentId, errorMessages) {
     };
 
     return dispatch => apiService.surveys.postAnswer(assessmentId, requestBody)
-    .catch((assessErr) => {
-        dispatch(_reportSurveyError(assessErr, errorMessages.ANSWER_REQUEST));
-        throw assessErr;
-    });
+        .catch((assessErr) => {
+            dispatch(_reportSurveyError(assessErr, errorMessages.ANSWER_REQUEST));
+            throw assessErr;
+        });
 }
 
 export function getAnswers(assessmentId, errorMessages) {
-    return dispatch =>
-        apiService.surveys.getAnswers(assessmentId)
+    return dispatch => apiService.surveys.getAnswers(assessmentId)
         .then((answerResp) => {
             dispatch(_getAnswersSuccess(answerResp.answers));
             return answerResp;
@@ -112,8 +111,7 @@ export function getAnswers(assessmentId, errorMessages) {
 
 // Answer related.
 export function postAnswer(assessmentId, requestBody, errorMessages) {
-    return dispatch =>
-        apiService.surveys.postAnswer(assessmentId, requestBody)
+    return dispatch => apiService.surveys.postAnswer(assessmentId, requestBody)
         .then((answerResp) => {
             dispatch(_postAnswerSuccess(requestBody));
             return answerResp;
@@ -129,8 +127,7 @@ export function postReview(assessmentId, answers, errorMessages) {
         status: 'in-progress',
         answers,
     };
-    return dispatch =>
-        apiService.surveys.postAnswer(assessmentId, requestBody)
+    return dispatch => apiService.surveys.postAnswer(assessmentId, requestBody)
         .then((answerResp) => {
             dispatch(getAnswers(assessmentId, errorMessages));
             return answerResp;

--- a/src/common/actions/taskActions.js
+++ b/src/common/actions/taskActions.js
@@ -10,42 +10,39 @@ import apiService from '../../services/api';
 export function getTasksByProduct(productId, projectId, errorMessages) {
     return (dispatch) => {
         apiService.tasks.getTasksByProduct(productId)
-        .then((taskResp) => {
-            dispatch(_getTasksByProductSuccess(projectId, taskResp));
-            return taskResp;
-        })
-        .catch((taskErr) => {
-            dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS));
-        });
+            .then((taskResp) => {
+                dispatch(_getTasksByProductSuccess(projectId, taskResp));
+                return taskResp;
+            })
+            .catch((taskErr) => {
+                dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS));
+            });
     };
 }
 
 export function getTaskById(projectId, taskId, errorMessages) {
-    return dispatch =>
-    apiService.tasks.getTaskById(taskId)
-    .then((taskResp) => {
-        dispatch(getAnswers(taskResp.assessmentId, errorMessages));
-        dispatch(getProjectById(projectId, false, errorMessages));
-        dispatch(_getTaskByIdSuccess(projectId, taskResp));
-    })
-    .catch((taskErr) => {
-        dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS));
-    });
+    return dispatch => apiService.tasks.getTaskById(taskId)
+        .then((taskResp) => {
+            dispatch(getAnswers(taskResp.assessmentId, errorMessages));
+            dispatch(getProjectById(projectId, false, errorMessages));
+            dispatch(_getTaskByIdSuccess(projectId, taskResp));
+        })
+        .catch((taskErr) => {
+            dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS));
+        });
 }
 
 export function getSelfTasks(errorMessages) {
-    return dispatch =>
-    apiService.tasks.getSelfTasks()
-    .then(taskResp => dispatch(_getTasksByUserSuccess(taskResp[0].userIds[0], taskResp)))
-    .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS)));
+    return dispatch => apiService.tasks.getSelfTasks()
+        .then(taskResp => dispatch(_getTasksByUserSuccess(taskResp[0].userIds[0], taskResp)))
+        .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS)));
 }
 
 
 export function getTasksByUser(userId, errorMessages) {
-    return dispatch =>
-    apiService.tasks.getTasksByUser(userId)
-    .then(taskResp => dispatch(_getTasksByUserSuccess(userId, taskResp)))
-    .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS)));
+    return dispatch => apiService.tasks.getTasksByUser(userId)
+        .then(taskResp => dispatch(_getTasksByUserSuccess(userId, taskResp)))
+        .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.FETCH_TASKS)));
 }
 
 export function assignTask(userId, slot, project, errorMessages) {
@@ -78,33 +75,33 @@ export function assignTask(userId, slot, project, errorMessages) {
 
     return (dispatch) => {
         apiService.surveys.postAssessment(surveyRequestBody)
-        .then((assessmentResp) => {
-            requestBody.assessmentId = assessmentResp.id;
-            apiService.tasks.postTask(requestBody)
-            .then(taskResp => dispatch(_postTaskSuccess(taskResp)))
-            .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.TASK_REQUEST)));
-        })
-        .catch((assessmentErr) => {
-            dispatch(_reportTasksError(assessmentErr, errorMessages.ASSESSMENT_REQUEST));
-        });
+            .then((assessmentResp) => {
+                requestBody.assessmentId = assessmentResp.id;
+                apiService.tasks.postTask(requestBody)
+                    .then(taskResp => dispatch(_postTaskSuccess(taskResp)))
+                    .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.TASK_REQUEST)));
+            })
+            .catch((assessmentErr) => {
+                dispatch(_reportTasksError(assessmentErr, errorMessages.ASSESSMENT_REQUEST));
+            });
     };
 }
 
 export function moveTask(productId, uoaId, errorMessages) {
     return dispatch => apiService.tasks.moveTask(productId, uoaId)
-    .then(() => dispatch(push('/task')))
-    .catch((workflowErr) => {
-        dispatch(_reportTasksError(workflowErr, errorMessages.TASK_REQUEST));
-        throw workflowErr;
-    });
+        .then(() => dispatch(push('/task')))
+        .catch((workflowErr) => {
+            dispatch(_reportTasksError(workflowErr, errorMessages.TASK_REQUEST));
+            throw workflowErr;
+        });
 }
 
 export function forceTaskCompletion(productId, uoaId, errorMessages) {
     return (dispatch) => {
         return apiService.tasks.forceMoveTask(productId, uoaId)
-        .catch((workflowErr) => {
-            dispatch(_reportTasksError(workflowErr, errorMessages.TASK_REQUEST));
-        });
+            .catch((workflowErr) => {
+                dispatch(_reportTasksError(workflowErr, errorMessages.TASK_REQUEST));
+            });
     };
 }
 
@@ -129,8 +126,8 @@ export function updateTask(taskId, userIds, endDate, errorMessages) {
 
     return (dispatch) => {
         apiService.tasks.putTask(taskId, requestBody)
-        .then(() => dispatch(_putTaskSuccess(taskId, requestBody)))
-        .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.TASK_REQUEST)));
+            .then(() => dispatch(_putTaskSuccess(taskId, requestBody)))
+            .catch(taskErr => dispatch(_reportTasksError(taskErr, errorMessages.TASK_REQUEST)));
     };
 }
 

--- a/src/common/actions/taskActions.js
+++ b/src/common/actions/taskActions.js
@@ -2,8 +2,8 @@ import { toast } from 'react-toastify';
 import { pickBy, identity } from 'lodash';
 import { push } from 'react-router-redux';
 
-import { getAnswers } from '../actions/surveyActions';
-import { getProjectById } from '../actions/projectActions';
+import { getAnswers } from './surveyActions';
+import { getProjectById } from './projectActions';
 import * as actionTypes from '../actionTypes/taskActionTypes';
 import apiService from '../../services/api';
 

--- a/src/common/actions/userActions.js
+++ b/src/common/actions/userActions.js
@@ -6,12 +6,12 @@ import * as actionTypes from '../actionTypes/userActionTypes';
 export function getProfile(errorMessages) {
     return (dispatch) => {
         return apiService.users.getProfile()
-        .then((profileResp) => {
-            dispatch(getProfileSuccess(profileResp));
-            return profileResp;
-        }).catch((profileErr) => {
-            dispatch(_reportUserError(profileErr, errorMessages.FETCH_PROFILE));
-        });
+            .then((profileResp) => {
+                dispatch(getProfileSuccess(profileResp));
+                return profileResp;
+            }).catch((profileErr) => {
+                dispatch(_reportUserError(profileErr, errorMessages.FETCH_PROFILE));
+            });
     };
 }
 
@@ -34,10 +34,10 @@ export function updateProfile(userData, errorMessages) {
 
     return (dispatch) => {
         return apiService.users.putProfile(requestBody)
-        .then(() => dispatch(getProfile(errorMessages)))
-        .catch((profileErr) => {
-            dispatch(_reportUserError(profileErr, errorMessages.PROFILE_REQUEST));
-        });
+            .then(() => dispatch(getProfile(errorMessages)))
+            .catch((profileErr) => {
+                dispatch(_reportUserError(profileErr, errorMessages.PROFILE_REQUEST));
+            });
     };
 }
 
@@ -46,14 +46,14 @@ export function updateProfileById(id, userData, errorMessages) {
         dispatch(_updateProfileById());
 
         return apiService.users.putProfileById(id, userData)
-        .then((response) => {
-            dispatch(_updateProfileByIdSuccess(response));
-            dispatch(getUsers(errorMessages));
-            return response;
-        })
-        .catch((err) => {
-            dispatch(_updateProfileByIdFailure(err, errorMessages.PROFILE_REQUEST));
-        });
+            .then((response) => {
+                dispatch(_updateProfileByIdSuccess(response));
+                dispatch(getUsers(errorMessages));
+                return response;
+            })
+            .catch((err) => {
+                dispatch(_updateProfileByIdFailure(err, errorMessages.PROFILE_REQUEST));
+            });
     };
 }
 
@@ -82,12 +82,12 @@ export function resetPassword(errorMessages) {
 export function getUsers(errorMessages) {
     return (dispatch) => {
         return apiService.users.getUsers()
-        .then((users) => {
-            dispatch(_getUsersSuccess(users));
-            return users;
-        }).catch((err) => {
-            dispatch(_reportUserError(err, errorMessages.SERVER_ISSUE));
-        });
+            .then((users) => {
+                dispatch(_getUsersSuccess(users));
+                return users;
+            }).catch((err) => {
+                dispatch(_reportUserError(err, errorMessages.SERVER_ISSUE));
+            });
     };
 }
 
@@ -106,17 +106,17 @@ export function addNewUser(userData, projectId, orgId, toastMessages, errorMessa
 
     return (dispatch) => {
         apiService.users.inviteNewUser(requestBody)
-        .then((userResp) => {
-            toast(userResp.registered ? toastMessages.EXISTS : toastMessages.INVITED);
-            dispatch(_postNewUserSuccess(userResp, projectId));
-            return userResp;
-        })
-        .catch((userErr) => {
-            if (userErr.e === 403) {
-                toast(errorMessages.DUPLICATE);
-            }
-            dispatch(_reportUserError(userErr, errorMessages.USER_REQUEST));
-        });
+            .then((userResp) => {
+                toast(userResp.registered ? toastMessages.EXISTS : toastMessages.INVITED);
+                dispatch(_postNewUserSuccess(userResp, projectId));
+                return userResp;
+            })
+            .catch((userErr) => {
+                if (userErr.e === 403) {
+                    toast(errorMessages.DUPLICATE);
+                }
+                dispatch(_reportUserError(userErr, errorMessages.USER_REQUEST));
+            });
     };
 }
 
@@ -124,13 +124,13 @@ export function deleteUser(userId, errorMessages) {
     return (dispatch) => {
         dispatch(_deleteUser());
         apiService.users.deleteUser(userId)
-        .then(() => {
-            dispatch(_deleteUserSuccess(userId));
-        })
-        .catch((err) => {
-            dispatch(_deleteUserError(err, errorMessages.USER_REQUEST));
-            dispatch(_reportUserError(err, errorMessages.USER_REQUEST));
-        });
+            .then(() => {
+                dispatch(_deleteUserSuccess(userId));
+            })
+            .catch((err) => {
+                dispatch(_deleteUserError(err, errorMessages.USER_REQUEST));
+                dispatch(_reportUserError(err, errorMessages.USER_REQUEST));
+            });
     };
 }
 

--- a/src/common/components/AddUserModal/index.js
+++ b/src/common/components/AddUserModal/index.js
@@ -24,7 +24,7 @@ class AddUserModal extends Component {
                             this.props.vocab.ERROR,
                         );
                     }
-                }/>
+                    }/>
             </Modal>
         );
     }

--- a/src/common/components/CardValueDropdown.js
+++ b/src/common/components/CardValueDropdown.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Box } from 'grommet';
+import Box from 'grommet/components/Box';
 import enhanceWithClickOutside from 'react-click-outside';
 import IonIcon from 'react-ionicons';
 

--- a/src/common/components/Dashboard/FlagCount.js
+++ b/src/common/components/Dashboard/FlagCount.js
@@ -9,11 +9,11 @@ class FlagCount extends Component {
             <div className='flag-count'>
                 <IonIcon icon='ion-ios-flag'
                     className='flag-count__icon'/>
-                    {this.props.value > 0 &&
-                        <div className='flag-count__value'>
+                {this.props.value > 0
+                        && <div className='flag-count__value'>
                             {this.props.value}
                         </div>
-                    }
+                }
             </div>
         );
     }

--- a/src/common/components/Dashboard/MessageList.js
+++ b/src/common/components/Dashboard/MessageList.js
@@ -22,9 +22,9 @@ class MessageList extends Component {
                             <div className='message-list__unread-indicator' />
                             <div className={'message-list__name'}
                                 title= {renderNameByEmail(message.from, this.props.users)}>
-                                    {
-                                        renderNameByEmail(message.from, this.props.users)
-                                    }
+                                {
+                                    renderNameByEmail(message.from, this.props.users)
+                                }
                             </div>
                             <div className='message-list__subject'>
                                 {message.subject}
@@ -32,7 +32,7 @@ class MessageList extends Component {
                             <div className='message-list__time'>
                                 {Time.renderForMessageList(message.createdAt)}
                             </div>
-                            </div>);
+                        </div>);
                 })}
             </div>
         );

--- a/src/common/components/Dashboard/SplitLayout.js
+++ b/src/common/components/Dashboard/SplitLayout.js
@@ -1,7 +1,6 @@
 import React from 'react';
 
-export default ({ children }) =>
-    <div className='split-layout'>
-        <div className='split-layout__child'>{children[0]}</div>
-        <div className='split-layout__child'>{children[1]}</div>
-    </div>;
+export default ({ children }) => <div className='split-layout'>
+    <div className='split-layout__child'>{children[0]}</div>
+    <div className='split-layout__child'>{children[1]}</div>
+</div>;

--- a/src/common/components/DateInput/Calendar.js
+++ b/src/common/components/DateInput/Calendar.js
@@ -9,8 +9,7 @@ const Calendar = ({ onChange, value, pickerProps = {} }) => (
 
         displayOptions={Object.assign({},
             { layout: 'portrait' },
-            pickerProps.displayOptions,
-        )}
+            pickerProps.displayOptions)}
 
         theme={Object.assign({}, {
             selectionColor: 'rgb(48, 130, 82)',

--- a/src/common/components/DateInput/index.js
+++ b/src/common/components/DateInput/index.js
@@ -16,29 +16,34 @@ class DateInput extends Component {
 
         this.expand = this.expand.bind(this);
     }
+
     handleClickOutside() {
         this.setState({ expanded: false });
     }
+
     expand() {
         this.setState({ expanded: true });
     }
+
     render() {
-        const { value, onChange, inline, pickerProps } = this.props;
+        const {
+            value, onChange, inline, pickerProps,
+        } = this.props;
         const { expanded } = this.state;
         return (
             <div className='date-input'>
                 {
-                    expanded ?
-                    <div className={`date-input__calendar-wrapper ${inline ? 'date-input__calendar-wrapper--inline' : ''}`}>
-                        <Calendar value={value} onChange={onChange}
-                            pickerProps={pickerProps} />
-                    </div> :
-                    <div className='date-input__value'
-                        onClick={this.expand}>
-                        {Time.renderCommon(value)}
-                        <IonIcon icon='ion-android-calendar'
-                            className='date-input__value-icon'/>
-                    </div>
+                    expanded
+                        ? <div className={`date-input__calendar-wrapper ${inline ? 'date-input__calendar-wrapper--inline' : ''}`}>
+                            <Calendar value={value} onChange={onChange}
+                                pickerProps={pickerProps} />
+                        </div>
+                        : <div className='date-input__value'
+                            onClick={this.expand}>
+                            {Time.renderCommon(value)}
+                            <IonIcon icon='ion-android-calendar'
+                                className='date-input__value-icon'/>
+                        </div>
                 }
             </div>
         );

--- a/src/common/components/Filter.js
+++ b/src/common/components/Filter.js
@@ -5,21 +5,20 @@ class Filter extends Component {
     isActive(key) {
         if (typeof this.props.active === 'string') {
             return key === this.props.active;
-        } else if (typeof this.props.active === 'object') {
+        } if (typeof this.props.active === 'object') {
             return this.props.active.includes(key);
         }
         return false;
     }
+
     render() {
         return (
             <div className={`filter ${this.props.noSpace ? 'filter--no-space' : ''}`}>
-                {this.props.filters.map(filter =>
-                    <div className={`filter__button ${this.isActive(filter.key) ? 'filter__button--active' : ''}`}
-                        key={filter.key}
-                        onClick={() => this.props.onFilterClick(filter.key)}>
-                        {filter.label}
-                    </div>,
-                )}
+                {this.props.filters.map(filter => <div className={`filter__button ${this.isActive(filter.key) ? 'filter__button--active' : ''}`}
+                    key={filter.key}
+                    onClick={() => this.props.onFilterClick(filter.key)}>
+                    {filter.label}
+                </div>)}
             </div>
         );
     }

--- a/src/common/components/Modal/FooterButton.js
+++ b/src/common/components/Modal/FooterButton.js
@@ -4,9 +4,9 @@ import PropTypes from 'prop-types';
 class FooterButton extends Component {
     render() {
         return (
-            <div className={`footer-button ${this.props.primary ?
-                    'footer-button__primary' : ''}`}
-                onClick={this.props.onClick}>
+            <div className={`footer-button ${this.props.primary
+                ? 'footer-button__primary' : ''}`}
+            onClick={this.props.onClick}>
                 {this.props.label}
             </div>
         );

--- a/src/common/components/Modal/index.js
+++ b/src/common/components/Modal/index.js
@@ -15,30 +15,28 @@ class Modal extends Component {
                 onClose={this.props.onCancel}>
                 <div className={`modal-c ${this.props.class || ''}`}>
                     {
-                        this.props.title &&
-                        <div className='modal-c__title'>{this.props.title}</div>
+                        this.props.title
+                        && <div className='modal-c__title'>{this.props.title}</div>
                     }
                     <div className='modal-c__container'>
                         {
-                            this.props.bodyText &&
-                            <div className='modal-c__body-text'>{this.props.bodyText}</div>
+                            this.props.bodyText
+                            && <div className='modal-c__body-text'>{this.props.bodyText}</div>
                         }
                         {this.props.children}
                     </div>
                     <div className='modal-c__footer'>
                         <div className='modal-c__left-button-wrapper'>
-                            {(this.props.buttons || []).map(button =>
-                                <FooterButton {...button} key={button.key}/>,
-                            )}
+                            {(this.props.buttons || []).map(button => <FooterButton {...button} key={button.key}/>)}
                         </div>
                         <div className='modal-c__button-wrapper'>
-                            {this.props.onCancel &&
-                                <FooterButton
+                            {this.props.onCancel
+                                && <FooterButton
                                     label={this.props.vocab.COMMON.CANCEL}
                                     onClick={this.props.onCancel}/>
                             }
-                            {this.props.onSave &&
-                                <FooterButton
+                            {this.props.onSave
+                                && <FooterButton
                                     label={this.props.saveLabel || this.props.vocab.COMMON.SAVE}
                                     primary={true}
                                     onClick={this.props.onSave}/>
@@ -70,9 +68,9 @@ const mapStateToProps = state => ({
     vocab: state.settings.language.vocabulary,
 });
 const mapDispatchToProps = (dispatch, ownProps) => {
-    return ownProps.form ?
-        { onSave: () => dispatch(submit(ownProps.form)) } :
-        {};
+    return ownProps.form
+        ? { onSave: () => dispatch(submit(ownProps.form)) }
+        : {};
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Modal);

--- a/src/common/components/Modal/index.js
+++ b/src/common/components/Modal/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Layer } from 'grommet';
+import Layer from 'grommet/components/Layer';
 import { submit } from 'redux-form';
 
 import FooterButton from './FooterButton';

--- a/src/common/components/PMUserList/PMUserListHeader.js
+++ b/src/common/components/PMUserList/PMUserListHeader.js
@@ -6,8 +6,8 @@ export default ({ vocab, groups }) => (
             {vocab.COMMON.NAME}
         </div>
         {
-            groups &&
-            <div className='pm-user-list-header__cell'>
+            groups
+            && <div className='pm-user-list-header__cell'>
                 {vocab.PROJECT.USER_GROUPS}
             </div>
         }

--- a/src/common/components/PMUserList/PMUserListRow.js
+++ b/src/common/components/PMUserList/PMUserListRow.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import IonIcon from 'react-ionicons';
 import UserStatus from './UserStatus';
-import DeleteIconButton from '../../../common/components/DeleteIconButton';
+import DeleteIconButton from '../DeleteIconButton';
 
 import { renderName } from '../../../utils/User';
 
@@ -16,8 +16,8 @@ class PMUserListRow extends Component {
                     {renderName(this.props.user)}
                 </div>
                 {
-                    this.props.groups !== undefined &&
-                    <div className='pm-user-list-row__cell pm-user-list-row__cell--non-cursor'>
+                    this.props.groups !== undefined
+                    && <div className='pm-user-list-row__cell pm-user-list-row__cell--non-cursor'>
                         {
                             this.props.groups
                                 .filter(g => g.users.includes(this.props.user.id))

--- a/src/common/components/PMUserList/UserStatus.js
+++ b/src/common/components/PMUserList/UserStatus.js
@@ -6,9 +6,9 @@ class UserStatus extends Component {
     render() {
         return (
             <div className='user-status'>
-                {this.props.user.lastActive === null ?
-                    this.props.vocab.COMMON.PENDING :
-                    <IonIcon icon='ion-android-checkmark-circle'
+                {this.props.user.lastActive === null
+                    ? this.props.vocab.COMMON.PENDING
+                    : <IonIcon icon='ion-android-checkmark-circle'
                         className={`user-status__icon${this.props.user.isActive ? '' : '--inactive'}`} />}
             </div>
         );

--- a/src/common/components/PMUserList/index.js
+++ b/src/common/components/PMUserList/index.js
@@ -10,14 +10,13 @@ class PMUserList extends Component {
             <div className='pm-user-list'>
                 <PMUserListHeader vocab={this.props.vocab} groups={!!this.props.groups} />
                 {
-                    this.props.users.map(user =>
-                        <PMUserListRow user={user}
-                            groups={this.props.groups}
-                            key={user.id}
-                            onNameClick={() => this.props.onUserNameClick(user.id)}
-                            onDeleteClick={() => this.props.onUserDeleteClick(user.id)}
-                            onMailClick={() => this.props.onUserMailClick(user.id)}
-                            vocab={this.props.vocab}/>)
+                    this.props.users.map(user => <PMUserListRow user={user}
+                        groups={this.props.groups}
+                        key={user.id}
+                        onNameClick={() => this.props.onUserNameClick(user.id)}
+                        onDeleteClick={() => this.props.onUserDeleteClick(user.id)}
+                        onMailClick={() => this.props.onUserMailClick(user.id)}
+                        vocab={this.props.vocab}/>)
                 }
             </div>
         );

--- a/src/common/components/Search.js
+++ b/src/common/components/Search.js
@@ -9,18 +9,20 @@ class Search extends Component {
         this.state = { listOpen: false };
         this.handleClickOutside = this.handleClickOutside.bind(this);
     }
+
     handleClickOutside() {
         this.setState(() => ({ listOpen: false }));
     }
+
     render() {
         return <div onBlur={() => this.handleClickOutside()}>
             <div className='search'>
                 <input className='search__input'
-                       type='text'
-                       placeholder={this.props.placeholder}
-                       value={this.props.value}
-                       onChange={this.props.onChange}
-                       onClick={() => { this.setState(prev => ({ listOpen: !prev.listOpen })); }}
+                    type='text'
+                    placeholder={this.props.placeholder}
+                    value={this.props.value}
+                    onChange={this.props.onChange}
+                    onClick={() => { this.setState(prev => ({ listOpen: !prev.listOpen })); }}
                 />
                 <IonIcon className='search__icon' icon='ion-android-search'/>
             </div>

--- a/src/common/components/SelectGroupUsers/FilteredList.js
+++ b/src/common/components/SelectGroupUsers/FilteredList.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import List from './List';
-import FilterInput from '../../../common/components/Dashboard/FilterInput';
+import FilterInput from '../Dashboard/FilterInput';
 
 class FilteredList extends Component {
     constructor(props) {

--- a/src/common/components/SelectGroupUsers/List.js
+++ b/src/common/components/SelectGroupUsers/List.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class List extends Component {
-
     renderListItem() {
         if (this.props.itemsJSX) {
             return this.props.itemsJSX;
@@ -23,6 +22,7 @@ class List extends Component {
         });
         return items;
     }
+
     render() {
         return (
             <div className={this.props.className || 'filtered-list'}>

--- a/src/common/components/SelectGroupUsers/index.js
+++ b/src/common/components/SelectGroupUsers/index.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { compact, filter, get } from 'lodash';
 import { toast } from 'react-toastify';
 
-import Modal from '../../../common/components/Modal';
+import Modal from '../Modal';
 import FilteredList from './FilteredList';
 import { renderName } from '../../../utils/User';
 
@@ -26,18 +26,23 @@ class SelectGroupUsers extends Component {
         this.handleRemoveAll = this.handleRemoveAll.bind(this);
         this.createUserListItem = this.createUserListItem.bind(this);
     }
+
     nonGroupIds() {
         return this.props.users.filter(userId => !this.state.groupUserIds.includes(userId));
     }
+
     handleGroupTitle(evt) {
         this.setState({ groupTitle: evt.target.value });
     }
+
     handleProjectUsersSelect(selection) {
         this.setState({ projectUsersSelected: selection.length ? selection : [selection] });
     }
+
     handleGroupUsersSelect(selection) {
         this.setState({ groupUsersSelected: selection.length ? selection : [selection] });
     }
+
     handleAdd() {
         const nonGroupIds = this.nonGroupIds();
         const newGroupUserIds = [...this.state.groupUserIds];
@@ -49,9 +54,10 @@ class SelectGroupUsers extends Component {
                 ...this.state.groupUserIds,
                 ...this.state.projectUsersSelected.map(userIndex => nonGroupIds[userIndex]),
             ],
-            projectUsersSelected: [] },
-        );
+            projectUsersSelected: [],
+        });
     }
+
     handleAddAll() {
         this.setState({
             groupUserIds:
@@ -59,16 +65,18 @@ class SelectGroupUsers extends Component {
             projectUsersSelected: [],
         });
     }
+
     handleRemove() {
         const selectedIds = this.state.groupUsersSelected
             .map(index => this.state.groupUserIds[index]);
         this.setState({
             groupUserIds: this.state.groupUserIds
-                    .filter(userId => !selectedIds.includes(userId)),
+                .filter(userId => !selectedIds.includes(userId)),
             groupUsersSelected: [],
             projectUsersSelected: [],
         });
     }
+
     handleRemoveAll() {
         this.setState({
             groupUserIds: [],
@@ -76,6 +84,7 @@ class SelectGroupUsers extends Component {
             projectUsersSelected: [],
         });
     }
+
     createUserListItem(userId) {
         const user = this.props.allUsers.find(allUser => allUser.id === userId);
         return {
@@ -85,16 +94,16 @@ class SelectGroupUsers extends Component {
             label: renderName(user),
         };
     }
+
     render() {
         const nonGroupIds = this.nonGroupIds();
         return (
             <Modal
                 onCancel={this.props.onCancel}
-                onSave={(this.state.groupTitle !== '') ?
-                    () => {
+                onSave={(this.state.groupTitle !== '')
+                    ? () => {
                         const groupId = get(this.props, 'group.id', null);
-                        const duplicates = filter(this.props.userGroups, group =>
-                            group.title === this.state.groupTitle && group.id !== groupId);
+                        const duplicates = filter(this.props.userGroups, group => group.title === this.state.groupTitle && group.id !== groupId);
                         if (duplicates.length > 0) {
                             toast(this.props.vocab.ERROR.DUPLICATE);
                         } else {
@@ -103,8 +112,8 @@ class SelectGroupUsers extends Component {
                                 users: this.state.groupUserIds,
                             });
                         }
-                    } :
-                    undefined}
+                    }
+                    : undefined}
                 title={this.props.vocab.PROJECT.ADD_USER_GROUP}>
                 <div className='select-group-users'>
                     {this.props.vocab.STAGE.GROUP_NAME}

--- a/src/common/components/StatusLabel.js
+++ b/src/common/components/StatusLabel.js
@@ -13,8 +13,7 @@ const _modifiers = {
     [StatusLabelType.NEUTRAL]: 'neutral',
 };
 
-const StatusLabel = ({ label, type }) =>
-    <div className={`status-label status-label--${_modifiers[type]}`}>{label}</div>;
+const StatusLabel = ({ label, type }) => <div className={`status-label status-label--${_modifiers[type]}`}>{label}</div>;
 
 StatusLabel.propTypes = {
     type: PropTypes.oneOf(Object.keys(StatusLabelType)

--- a/src/common/components/SubjectList.js
+++ b/src/common/components/SubjectList.js
@@ -9,9 +9,11 @@ class SubjectList extends Component {
         super(props);
         this.filter = this.filter.bind(this);
     }
+
     filter(subject) {
         return subject.name.toLowerCase().includes(this.props.query.toLowerCase());
     }
+
     render() {
         return (
             <div className='subject-list'>
@@ -37,14 +39,13 @@ class SubjectList extends Component {
                         {this.props.vocab.COMMON.ACTIONS}
                     </div>
                 </div>
-                {this.props.subjects.filter(this.filter).map(subject =>
-                    <div className='subject-list__entry'
-                        key={subject.id}>
-                        <div className='subject-list__entry-name'>
-                            {subject.name}
-                        </div>
-                        <DeleteIconButton onClick={() => this.props.onDeleteClick(subject)} />
-                    </div>)
+                {this.props.subjects.filter(this.filter).map(subject => <div className='subject-list__entry'
+                    key={subject.id}>
+                    <div className='subject-list__entry-name'>
+                        {subject.name}
+                    </div>
+                    <DeleteIconButton onClick={() => this.props.onDeleteClick(subject)} />
+                </div>)
                 }
             </div>);
     }

--- a/src/common/components/Summary/StatusCard.js
+++ b/src/common/components/Summary/StatusCard.js
@@ -16,8 +16,8 @@ class StatusCard extends Component {
                         <div className='status-card__name-value'
                             onClick={this.props.onEditClick}>
                             { this.props.name }
-                            {this.props.onEditClick &&
-                                <div className='status-card__edit-icon'
+                            {this.props.onEditClick
+                                && <div className='status-card__edit-icon'
                                     onClick={this.props.onEditClick}>
                                     <IonIcon icon='ion-android-create'
                                         className='status-card__edit-icon'/>
@@ -29,8 +29,8 @@ class StatusCard extends Component {
                 <div className={`status-card__status ${this.props.onStatusChangeClick ? 'status-card__status--editable' : ''}`}
                     onClick={this.props.onStatusChangeClick}>
                     {this.props.status}
-                    {this.props.onStatusChangeClick &&
-                        <IonIcon icon='ion-android-create' className='status-card__create-icon'/>}
+                    {this.props.onStatusChangeClick
+                        && <IonIcon icon='ion-android-create' className='status-card__create-icon'/>}
                 </div>
             </div>
         );

--- a/src/common/components/Summary/index.js
+++ b/src/common/components/Summary/index.js
@@ -12,12 +12,12 @@ class Summary extends Component {
                     label={this.props.vocab.PROJECT.PROJECT}
                     name={this.props.project ? this.props.project.name : ''}
                     actions={this.props.actions}
-                    status={this.props.project.status ?
-                        this.props.vocab.PROJECT.STATUS_ACTIVE :
-                        this.props.vocab.PROJECT.STATUS_INACTIVE}
+                    status={this.props.project.status
+                        ? this.props.vocab.PROJECT.STATUS_ACTIVE
+                        : this.props.vocab.PROJECT.STATUS_INACTIVE}
                     onStatusChangeClick={
-                        this.props.onStatusChangeClick &&
-                        (() => this.props.onStatusChangeClick('projectstatusmodal'))}
+                        this.props.onStatusChangeClick
+                        && (() => this.props.onStatusChangeClick('projectstatusmodal'))}
                     onEditClick={this.props.onProjectEditClick} />
                 <StatusCard
                     label={this.props.vocab.PROJECT.SURVEY}
@@ -25,8 +25,8 @@ class Summary extends Component {
                     actions={this.props.actions}
                     status={this.props.vocab.SURVEY[this.props.survey.status.toUpperCase()]}
                     onStatusChangeClick={
-                        this.props.onStatusChangeClick &&
-                        (() => this.props.onStatusChangeClick('surveystatusmodal'))}
+                        this.props.onStatusChangeClick
+                        && (() => this.props.onStatusChangeClick('surveystatusmodal'))}
                     onEditClick={this.props.onSurveyEditClick} >
                     <IonIcon
                         icon='ion-ios-paper-outline'

--- a/src/common/components/Tabs/Tab.js
+++ b/src/common/components/Tabs/Tab.js
@@ -5,8 +5,8 @@ class Tab extends Component {
     render() {
         const className = this.props.className ? `${this.props.className}__link` : 'tab__link';
         return (
-            <li className={(this.props.className ? `${this.props.className} ` : 'tab ') +
-                (this.props.classModifier ? `${this.props.className}--${this.props.classModifier}` : '')}>
+            <li className={(this.props.className ? `${this.props.className} ` : 'tab ')
+                + (this.props.classModifier ? `${this.props.className}--${this.props.classModifier}` : '')}>
                 <div className={className + (this.props.isActive ? ` ${className}--active ` : ' ')}
                     onClick={(event) => {
                         event.preventDefault();

--- a/src/common/components/Tabs/Tabs.js
+++ b/src/common/components/Tabs/Tabs.js
@@ -11,16 +11,16 @@ class Tabs extends Component {
     }
 
     componentWillReceiveProps(nextProps) {
-        if ((nextProps.activeTabIndex || nextProps.activeTabIndex === 0) &&
-            this.state.activeTabIndex !== nextProps.activeTabIndex) {
+        if ((nextProps.activeTabIndex || nextProps.activeTabIndex === 0)
+            && this.state.activeTabIndex !== nextProps.activeTabIndex) {
             this.setState({ activeTabIndex: nextProps.activeTabIndex });
         }
     }
 
     handleTabClick(tabIndex) {
         this.setState({
-            activeTabIndex: tabIndex ===
-                this.state.activeTabIndex ? this.props.defaultActiveTabIndex : tabIndex,
+            activeTabIndex: tabIndex
+                === this.state.activeTabIndex ? this.props.defaultActiveTabIndex : tabIndex,
         });
         if (this.props.onActive) {
             this.props.onActive(tabIndex);

--- a/src/common/components/TitleChange/SurveyTitleModal.js
+++ b/src/common/components/TitleChange/SurveyTitleModal.js
@@ -18,12 +18,14 @@ class SurveyTitleModal extends Component {
                             this.props.actions.patchSurvey(
                                 { name, id: this.props.survey.id },
                                 this.props.vocab.SURVEY.SUCCESS,
-                                this.props.vocab.ERROR);
+                                this.props.vocab.ERROR,
+                            );
                         } else {
                             this.props.actions.postSurvey(
                                 Object.assign({}, this.props.survey, { name }),
                                 this.props.project,
-                                this.props.vocab.ERROR);
+                                this.props.vocab.ERROR,
+                            );
                         }
                         this.props.onCloseModal();
                     }}/>

--- a/src/common/components/TitleChange/TitleForm.js
+++ b/src/common/components/TitleChange/TitleForm.js
@@ -6,7 +6,7 @@ class TitleForm extends Component {
     render() {
         return (
             <form className='title-form'
-              onSubmit={this.props.handleSubmit}>
+                onSubmit={this.props.handleSubmit}>
                 <label className='title-form__title-label'>
                     {this.props.label}
                     <Field name='title'

--- a/src/common/components/UserGroupList/UserGroupListEntry.js
+++ b/src/common/components/UserGroupList/UserGroupListEntry.js
@@ -2,12 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 import UserBadge from '../UserBadge';
-import DeleteIconButton from '../../../common/components/DeleteIconButton';
+import DeleteIconButton from '../DeleteIconButton';
 
 class UserGroupListEntry extends Component {
     render() {
         const users = this.props.group.users.map(
-            userId => this.props.users.find(user => user.id === userId));
+            userId => this.props.users.find(user => user.id === userId),
+        );
         return (
             <div className='user-group-list-entry'
                 onClick={this.props.onGroupClick} >
@@ -15,12 +16,10 @@ class UserGroupListEntry extends Component {
                     {this.props.group.title}
                 </div>
                 <div className='user-group-list-entry__badge-string'>
-                    {users.map(user =>
-                        user && <UserBadge key={user.id} user={user}/>,
-                    )}
+                    {users.map(user => user && <UserBadge key={user.id} user={user}/>)}
                 </div>
-                {this.props.onDeleteClick &&
-                    <DeleteIconButton onClick={(event) => {
+                {this.props.onDeleteClick
+                    && <DeleteIconButton onClick={(event) => {
                         this.props.onDeleteClick(this.props.group.id);
                         event.stopPropagation();
                     } } />

--- a/src/common/components/UserGroupList/index.js
+++ b/src/common/components/UserGroupList/index.js
@@ -8,8 +8,8 @@ class UserGroupList extends Component {
         return (
             <div className='user-group-list'>
                 {
-                    this.props.columnHeaders &&
-                    <div className='user-group-list__header'>
+                    this.props.columnHeaders
+                    && <div className='user-group-list__header'>
                         <div className={'user-group-list__header-section '
                             + 'user-group-list__header-section--name'}>
                             {this.props.vocab.PROJECT.GROUP_NAME}
@@ -24,14 +24,13 @@ class UserGroupList extends Component {
                         </div>
                     </div>
                 }
-                {this.props.groups.map(group =>
-                    <UserGroupListEntry
-                        key={group.id}
-                        group={group}
-                        onDeleteClick={this.props.onDeleteClick}
-                        onGroupClick={this.props.onGroupClick &&
-                            (() => this.props.onGroupClick(group.id))}
-                        users={this.props.users}/>)}
+                {this.props.groups.map(group => <UserGroupListEntry
+                    key={group.id}
+                    group={group}
+                    onDeleteClick={this.props.onDeleteClick}
+                    onGroupClick={this.props.onGroupClick
+                            && (() => this.props.onGroupClick(group.id))}
+                    users={this.props.users}/>)}
             </div>
         );
     }

--- a/src/common/components/ValidatedTextInput.js
+++ b/src/common/components/ValidatedTextInput.js
@@ -7,7 +7,8 @@ const ValidatedTextInput = ({
     placeholder,
     vocab,
     className,
-    password }) => {
+    password,
+}) => {
     const finalClassName = [
         'validated-text-input',
         (touched && error) ? 'validated-text-input--error' : '',

--- a/src/common/reducers/projectReducer.js
+++ b/src/common/reducers/projectReducer.js
@@ -36,79 +36,125 @@ export const ProjectReducer = (state = initialState, action) => {
 
     switch (action.type) {
     case type.POST_PROJECT_SUCCESS:
-        return state.data.length === 0 ?
-        update(state, { data: { $push: [action.project] } }) :
-        update(state, { data: { $set: [action.project] } });
+        return state.data.length === 0
+            ? update(state, { data: { $push: [action.project] } })
+            : update(state, { data: { $set: [action.project] } });
     case type.SHOW_ADD_SUBJECT_MODAL:
         return update(state, { ui: { showAddSubject: { $set: action.show } } });
     case type.GET_PROJECTS_SUCCESS:
-        return (state.data.length === 0 ?
-            update(state, { data: { $set: action.projects } }) :
-            update(state, { data: { $merge: action.projects } }));
+        return (state.data.length === 0
+            ? update(state, { data: { $set: action.projects } })
+            : update(state, { data: { $merge: action.projects } }));
     case type.GET_PROJECT_BY_ID_SUCCESS:
-        return (state.data.length === 0 ?
-            update(state, { data: { $set: [action.project] } }) :
-            update(state, { data: { [projectIndex]: { $merge: action.project } } }));
+        return (state.data.length === 0
+            ? update(state, { data: { $set: [action.project] } })
+            : update(state, { data: { [projectIndex]: { $merge: action.project } } }));
     case type.UPDATE_PROJECT_WITH_SURVEY:
         return update(state, { data: { [projectIndex]: { surveyId: { $set: action.surveyId } } } });
     case type.TOGGLE_FILTER:
-        return update(state, { data: { [projectIndex]: {
-            filter: { $apply: f => (f !== action.filter ? action.filter : '') } } } });
+        return update(state, {
+            data: {
+                [projectIndex]: { filter: { $apply: f => (f !== action.filter ? action.filter : '') } },
+            },
+        });
     case type.PUT_STAGE_SUCCESS: {
         const stageIndex = _.findIndex(state.data[projectIndex].stages,
             stage => stage.id === action.stage.id);
         if (stageIndex >= 0) {
-            return update(state, { data: { [projectIndex]: {
-                stages: { [stageIndex]: { $set: action.stage } },
-            } } });
+            return update(state, {
+                data: {
+                    [projectIndex]: {
+                        stages: { [stageIndex]: { $set: action.stage } },
+                    },
+                },
+            });
         }
-        return update(state, { data: { [projectIndex]: {
-            stages: { $push: [action.stage] },
-            lastUpdated: { $set: new Date().toISOString() },
-        } } });
+        return update(state, {
+            data: {
+                [projectIndex]: {
+                    stages: { $push: [action.stage] },
+                    lastUpdated: { $set: new Date().toISOString() },
+                },
+            },
+        });
     }
     case type.POST_SUBJECT_SUCCESS:
-        return update(state, { data: { [projectIndex]: {
-            subjects: { $set: _.concat(state.data[projectIndex].subjects, action.subjects) },
-            lastUpdated: { $set: new Date().toISOString() },
-        } } });
+        return update(state, {
+            data: {
+                [projectIndex]: {
+                    subjects: { $set: _.concat(state.data[projectIndex].subjects, action.subjects) },
+                    lastUpdated: { $set: new Date().toISOString() },
+                },
+            },
+        });
     case type.DELETE_SUBJECT_SUCCESS:
-        return update(state, { data: { [projectIndex]: {
-            subjects: { $apply: ss => ss.filter(subject => subject.id !== action.uoaId) },
-            lastUpdated: { $set: new Date().toISOString() },
-        } } });
+        return update(state, {
+            data: {
+                [projectIndex]: {
+                    subjects: { $apply: ss => ss.filter(subject => subject.id !== action.uoaId) },
+                    lastUpdated: { $set: new Date().toISOString() },
+                },
+            },
+        });
     case type.POST_PROJECT_USER_SUCCESS:
-        return update(state, { data: { [projectIndex]: {
-            users: { $push: [action.userId] } } } });
+        return update(state, {
+            data: {
+                [projectIndex]: { users: { $push: [action.userId] } },
+            },
+        });
     case type.DELETE_PROJECT_USER_SUCCESS:
-        return update(state, { data: { [projectIndex]: {
-            users: { $apply: users => users.filter(user => user !== action.userId),
-            } } } });
+        return update(state, {
+            data: {
+                [projectIndex]: {
+                    users: { $apply: users => users.filter(user => user !== action.userId) },
+                },
+            },
+        });
     case type.DELETE_USER_GROUP:
-        return update(state, { data: { [projectIndex]: {
-            userGroups: { $apply: userGroups =>
-                        userGroups.filter(userGroup => userGroup.id !== action.groupId),
-            } } } });
+        return update(state, {
+            data: {
+                [projectIndex]: {
+                    userGroups: {
+                        $apply: userGroups => userGroups.filter(userGroup => userGroup.id !== action.groupId),
+                    },
+                },
+            },
+        });
     case type.UPDATE_USER_GROUP: // TODO: INBA-457
         groupIndex = state[projectIndex].userGroups
-                    .findIndex(group => group.id === action.group.id);
-        return update(state, { data: { [projectIndex]: { userGroups: {
-            [groupIndex]: { $set: action.group },
-        } } } });
+            .findIndex(group => group.id === action.group.id);
+        return update(state, {
+            data: {
+                [projectIndex]: {
+                    userGroups: {
+                        [groupIndex]: { $set: action.group },
+                    },
+                },
+            },
+        });
     case POST_NEW_USER_SUCCESS:
-        return projectIndex >= 0 ?
-        update(state, { data: { [projectIndex]: {
-            users: { $push: [action.user.id] },
-            lastUpdated: { $set: new Date().toISOString() },
-        } } }) :
-        state;
+        return projectIndex >= 0
+            ? update(state, {
+                data: {
+                    [projectIndex]: {
+                        users: { $push: [action.user.id] },
+                        lastUpdated: { $set: new Date().toISOString() },
+                    },
+                },
+            })
+            : state;
     case type.REMOVE_USER:
-        return update(state, { data: { [projectIndex]: {
-            users: { $apply: users => users.filter(userId => userId !== action.userId) },
-            userGroups: { $apply: userGroups => userGroups.map(userGroup => update(userGroup, {
-                users: { $apply: users => users.filter(userId => userId !== action.userId) } })) },
-            lastUpdated: { $set: new Date().toISOString() },
-        } } });
+        return update(state, {
+            data: {
+                [projectIndex]: {
+                    users: { $apply: users => users.filter(userId => userId !== action.userId) },
+                    userGroups: {
+                        $apply: userGroups => userGroups.map(userGroup => update(userGroup, { users: { $apply: users => users.filter(userId => userId !== action.userId) } })),
+                    },
+                    lastUpdated: { $set: new Date().toISOString() },
+                },
+            },
+        });
     case type.REPORT_PROJECT_ERROR:
         return update(state, { ui: { errorMessage: { $set: action.errorMessage } } });
     case LOG_OUT:

--- a/src/common/reducers/surveyReducer.js
+++ b/src/common/reducers/surveyReducer.js
@@ -22,19 +22,19 @@ export const SurveyReducer = (state = initialState, action) => {
     const surveyIndex = _.findIndex(state.data, survey => survey.id === action.surveyId);
     switch (action.type) {
     case type.POST_SURVEY_SUCCESS:
-        return state.data[0].name ?
-            update(state, { data: { $push: [action.survey] }, ui: { newSurveyName: { $set: '' } } }) :
-            update(state, { data: { $set: [action.survey] }, ui: { newSurveyName: { $set: '' } } });
+        return state.data[0].name
+            ? update(state, { data: { $push: [action.survey] }, ui: { newSurveyName: { $set: '' } } })
+            : update(state, { data: { $set: [action.survey] }, ui: { newSurveyName: { $set: '' } } });
     case type.PATCH_SURVEY_SUCCESS:
         return update(state, { data: { [surveyIndex]: { $merge: action.survey } } });
     case type.GET_SURVEYS_SUCCESS:
-        return (!state.data[0].name ?
-            update(state, { data: { $set: action.surveys } }) :
-            update(state, { data: { $merge: action.surveys } }));
+        return (!state.data[0].name
+            ? update(state, { data: { $set: action.surveys } })
+            : update(state, { data: { $merge: action.surveys } }));
     case type.GET_SURVEY_BY_ID_SUCCESS:
-        return (!state.data[0].name ?
-            update(state, { data: { $set: [action.survey] } }) :
-            update(state, { data: { [surveyIndex]: { $merge: action.survey } } }));
+        return (!state.data[0].name
+            ? update(state, { data: { $set: [action.survey] } })
+            : update(state, { data: { [surveyIndex]: { $merge: action.survey } } }));
     case type.SET_SURVEY_SECTION_INDEX:
         return update(state, { ui: { sectionIndex: { $set: action.index } } });
     case type.REPORT_SURVEY_ERROR:

--- a/src/common/reducers/taskReducer.js
+++ b/src/common/reducers/taskReducer.js
@@ -25,11 +25,15 @@ export const TaskReducer = (state = initialState, action) => {
         });
     }
     case type.GET_TASK_BY_ID_SUCCESS:
-        return taskIndex < 0 ?
-            update(state, { projectId: { $set: action.projectId },
-                data: { $push: [action.task] } }) :
-            update(state, { projectId: { $set: action.projectId },
-                data: { [taskIndex]: { $set: action.task } } });
+        return taskIndex < 0
+            ? update(state, {
+                projectId: { $set: action.projectId },
+                data: { $push: [action.task] },
+            })
+            : update(state, {
+                projectId: { $set: action.projectId },
+                data: { [taskIndex]: { $set: action.task } },
+            });
     case type.GET_TASKS_BY_USER_SUCCESS:
         return update(state, {
             userId: { $set: action.userId },
@@ -38,13 +42,20 @@ export const TaskReducer = (state = initialState, action) => {
     case type.POST_TASK_SUCCESS:
         return update(state, { data: { $push: [action.task] } });
     case type.UPDATE_TASK_DUE_DATE:
-        return update(state, { data: { [taskIndex]:
-            { $merge: { endDate: action.endDate } } } });
+        return update(state, {
+            data: {
+                [taskIndex]:
+            { $merge: { endDate: action.endDate } },
+            },
+        });
     case type.PUT_TASK_SUCCESS:
         return update(state, { data: { [taskIndex]: { $merge: action.taskChanges } } });
     case DELETE_PROJECT_USER_SUCCESS:
-        return update(state, { data: { $apply: data => data.filter(task =>
-                !task.userIds.includes(action.userId)) } });
+        return update(state, {
+            data: {
+                $apply: data => data.filter(task => !task.userIds.includes(action.userId)),
+            },
+        });
     case type.REPORT_TASKS_ERROR:
         return update(state, { ui: { errorMessage: { $set: action.errorMessage } } });
     case LOG_OUT:

--- a/src/config/development.js
+++ b/src/config/development.js
@@ -1,6 +1,6 @@
 export default {
     NODE_ENV: 'development',
-    GREYSCALE_URL: window.GREYSCALE_URL||process.env.GREYSCALE_URL || 'http://localhost:3005',
+    GREYSCALE_URL: window.GREYSCALE_URL || process.env.GREYSCALE_URL || 'http://localhost:3005',
 
     AUTH_MICROSERVICE_URL: window.AUTH_MICROSERVICE_URL || process.env.AUTH_MICROSERVICE_URL || 'http://localhost:4000/api/v1',
 

--- a/src/index.js
+++ b/src/index.js
@@ -42,25 +42,25 @@ if (DEVELOP) {
     middleware = [...middleware, createLogger()];
 }
 
-const DevTools = DEVELOP ?
-createDevTools(
-  <DockMonitor
-    toggleVisibilityKey="ctrl-h"
-    changePositionKey="ctrl-q"
-    changeMonitorKey="ctrl-m"
-    fluid={true}
-    defaultSize={0.2}
-    defaultIsVisible={false}>
-      <LogMonitor />
-      <SliderMonitor />
-      <ChartMonitor />
-  </DockMonitor>,
-) :
-null;
+const DevTools = DEVELOP
+    ? createDevTools(
+        <DockMonitor
+            toggleVisibilityKey="ctrl-h"
+            changePositionKey="ctrl-q"
+            changeMonitorKey="ctrl-m"
+            fluid={true}
+            defaultSize={0.2}
+            defaultIsVisible={false}>
+            <LogMonitor />
+            <SliderMonitor />
+            <ChartMonitor />
+        </DockMonitor>,
+    )
+    : null;
 
-const enhancer = DEVELOP ?
-compose(applyMiddleware(...middleware), DevTools.instrument()) :
-applyMiddleware(...middleware);
+const enhancer = DEVELOP
+    ? compose(applyMiddleware(...middleware), DevTools.instrument())
+    : applyMiddleware(...middleware);
 
 const store = createStore(
     reducers,
@@ -73,12 +73,12 @@ const history = syncHistoryWithStore(browserHistory, store, {
 
 ReactDOM.render(
     <Provider store={store}>
-      <div className="main-page">
-          <Router history={history}>
-              {routes}
-          </Router>
-          { DEVELOP && <DevTools /> }
-      </div>
+        <div className="main-page">
+            <Router history={history}>
+                {routes}
+            </Router>
+            { DEVELOP && <DevTools /> }
+        </div>
     </Provider>,
     document.getElementById('root'),
 );

--- a/src/services/api/projects.js
+++ b/src/services/api/projects.js
@@ -7,35 +7,23 @@ const projects = {
     getProjects: () => requests.apiGetRequest(getFullPath('projects')),
     getProjectById: projectId => requests.apiGetRequest(getFullPath(`projects/${projectId}`)),
     postProject: requestBody => requests.apiPostRequest(getFullPath('projects'), requestBody),
-    putProject: (projectId, requestBody) =>
-        requests.apiPutRequest(getFullPath(`projects/${projectId}`), requestBody),
-    putSurveyToProduct: (productId, requestBody) =>
-        requests.apiPutRequest(getFullPath(`products/${productId}`), requestBody),
+    putProject: (projectId, requestBody) => requests.apiPutRequest(getFullPath(`projects/${projectId}`), requestBody),
+    putSurveyToProduct: (productId, requestBody) => requests.apiPutRequest(getFullPath(`products/${productId}`), requestBody),
     postUOA: requestBody => requests.apiPostRequest(getFullPath('uoas'), requestBody),
-    deleteUOA: (uoaId, requestBody) =>
-        requests.apiDeleteRequest(getFullPath(`uoas/${uoaId}`), requestBody),
-    postProjectUsers: (projectId, requestBody) =>
-        requests.apiPostRequest(getFullPath(`projects/${projectId}/users`), requestBody),
-    deleteProjectUsers: (projectId, userId) =>
-        requests.apiDeleteRequest(getFullPath(`projects/${projectId}/users/${userId}`), null),
-    postGroup: (organizationId, requestBody) =>
-        requests.apiPostRequest(getFullPath(`organizations/${organizationId}/groups`), requestBody),
-    putGroup: (groupId, requestBody) =>
-        requests.apiPutRequest(getFullPath(`groups/${groupId}`), requestBody),
+    deleteUOA: (uoaId, requestBody) => requests.apiDeleteRequest(getFullPath(`uoas/${uoaId}`), requestBody),
+    postProjectUsers: (projectId, requestBody) => requests.apiPostRequest(getFullPath(`projects/${projectId}/users`), requestBody),
+    deleteProjectUsers: (projectId, userId) => requests.apiDeleteRequest(getFullPath(`projects/${projectId}/users/${userId}`), null),
+    postGroup: (organizationId, requestBody) => requests.apiPostRequest(getFullPath(`organizations/${organizationId}/groups`), requestBody),
+    putGroup: (groupId, requestBody) => requests.apiPutRequest(getFullPath(`groups/${groupId}`), requestBody),
     deleteGroup: groupId => requests.apiDeleteRequest(getFullPath(`groups/${groupId}`), {}),
-    putWorkflowSteps: (workflowId, requestBody) =>
-        requests.apiPutRequest(getFullPath(`workflows/${workflowId}/steps`), requestBody),
-    deleteWorkflowStep: stepId =>
-        requests.apiDeleteRequest(getFullPath(`workflows/${stepId}/steps`), {}),
-    editSurvey: surveyId =>
-        requests.apiPutRequest(getFullPath(`projects/survey/${surveyId}`), {}),
-    exportData: productId =>
-        requests.apiGetRequest(getFullPath(`products/${productId}/export.csv`)),
+    putWorkflowSteps: (workflowId, requestBody) => requests.apiPutRequest(getFullPath(`workflows/${workflowId}/steps`), requestBody),
+    deleteWorkflowStep: stepId => requests.apiDeleteRequest(getFullPath(`workflows/${stepId}/steps`), {}),
+    editSurvey: surveyId => requests.apiPutRequest(getFullPath(`projects/survey/${surveyId}`), {}),
+    exportData: productId => requests.apiGetRequest(getFullPath(`products/${productId}/export.csv`)),
     postFileToAws: (file) => {
         const filename = `${file.name}_${uuid()}`;
         return requests.apiGetRequest(`${getFullPath('sign-s3')}?file-name=${filename}&file-type=${file.type}`)
-        .then(({ signedRequest, url }) =>
-            requests.putObjectRequest(file, signedRequest).then(() => ({ url, filename })));
+            .then(({ signedRequest, url }) => requests.putObjectRequest(file, signedRequest).then(() => ({ url, filename })));
     },
 };
 

--- a/src/services/api/requests.js
+++ b/src/services/api/requests.js
@@ -7,8 +7,8 @@ const makeQueryParams = (params) => {
         return '';
     }
     return `?${Object.keys(params)
-    .map(key => `${key}=${encodeURIComponent(params[key])}`)
-    .join('&')}`;
+        .map(key => `${key}=${encodeURIComponent(params[key])}`)
+        .join('&')}`;
 };
 
 export function addQueryParams(url, params) {
@@ -31,7 +31,7 @@ export function apiAuthPostRequest(fullURI, requestBodyObject) {
         },
         body: encodedRequestBodyObject,
     })
-    .then(handleResponse);
+        .then(handleResponse);
 }
 
 /**
@@ -49,7 +49,7 @@ export function apiGetRequest(fullURI) {
             Pragma: 'no-cache',
         },
     })
-    .then(handleResponse);
+        .then(handleResponse);
 }
 
 /**
@@ -67,7 +67,7 @@ export function apiPostRequest(fullURI, requestBody) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(handleResponse);
+        .then(handleResponse);
 }
 
 /**
@@ -85,7 +85,7 @@ export function apiPatchRequest(fullURI, requestBody) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(handleResponse);
+        .then(handleResponse);
 }
 
 /**
@@ -103,7 +103,7 @@ export function apiPutRequest(fullURI, requestBody) {
         },
         body: JSON.stringify(requestBody),
     })
-    .then(handleResponse);
+        .then(handleResponse);
 }
 
 /**
@@ -152,7 +152,7 @@ export function putObjectRequest(file, fullURI) {
         method: 'PUT',
         body: file,
     })
-    .then(handleResponse);
+        .then(handleResponse);
 }
 
 // ////////////////
@@ -162,9 +162,7 @@ function handleResponse(response) {
     if (response.ok) {
         return decodeResponse(response);
     }
-    return decodeResponse(response).then(body =>
-        Promise.reject({ response, body }),
-    );
+    return decodeResponse(response).then(body => Promise.reject({ response, body }));
 }
 
 function decodeResponse(res) {

--- a/src/services/api/surveys.js
+++ b/src/services/api/surveys.js
@@ -4,24 +4,15 @@ import config from '../../config';
 const rootURI = config.SURVEY_MICROSERVICE_URL;
 
 const surveys = {
-    getSurveys: () =>
-        requests.apiGetRequest(`${rootURI}/surveys?status=all`),
-    postSurvey: requestBody =>
-        requests.apiPostRequest(`${rootURI}/surveys`, requestBody),
-    patchSurvey: (surveyId, requestBody) =>
-        requests.apiPatchRequest(`${rootURI}/surveys/${surveyId}`, requestBody),
-    getSurveyById: surveyId =>
-        requests.apiGetRequest(`${rootURI}/surveys/${surveyId}`),
-    getAssessmentAnswersStatus: id =>
-        requests.apiGetRequest(`${rootURI}/assessment-answers/${id}/status`),
-    postAssessment: requestBody =>
-        requests.apiPostRequest(`${rootURI}/assessments`, requestBody),
-    getAnswers: assessmentId =>
-        requests.apiGetRequest(`${rootURI}/assessment-answers/${assessmentId}`),
-    postAnswer: (assessmentId, requestBody) =>
-        requests.apiPostRequest(`${rootURI}/assessment-answers/${assessmentId}`, requestBody),
-    postFile: (file, filename) =>
-        requests.multipartFormDataPostRequest(`${rootURI}/files`, { file, filename }),
+    getSurveys: () => requests.apiGetRequest(`${rootURI}/surveys?status=all`),
+    postSurvey: requestBody => requests.apiPostRequest(`${rootURI}/surveys`, requestBody),
+    patchSurvey: (surveyId, requestBody) => requests.apiPatchRequest(`${rootURI}/surveys/${surveyId}`, requestBody),
+    getSurveyById: surveyId => requests.apiGetRequest(`${rootURI}/surveys/${surveyId}`),
+    getAssessmentAnswersStatus: id => requests.apiGetRequest(`${rootURI}/assessment-answers/${id}/status`),
+    postAssessment: requestBody => requests.apiPostRequest(`${rootURI}/assessments`, requestBody),
+    getAnswers: assessmentId => requests.apiGetRequest(`${rootURI}/assessment-answers/${assessmentId}`),
+    postAnswer: (assessmentId, requestBody) => requests.apiPostRequest(`${rootURI}/assessment-answers/${assessmentId}`, requestBody),
+    postFile: (file, filename) => requests.multipartFormDataPostRequest(`${rootURI}/files`, { file, filename }),
 };
 
 export default surveys;

--- a/src/services/api/tasks.js
+++ b/src/services/api/tasks.js
@@ -2,13 +2,11 @@ import * as requests from './requests';
 import getFullPath from '../../utils/getFullPath';
 
 const tasks = {
-    getTasksByProduct: productId =>
-        requests.apiGetRequest(getFullPath(`products/${productId}/tasks`)),
-    forceMoveTask: (productId, uoaId) =>
-        requests.apiGetRequest(
-            requests.addQueryParams(getFullPath(`products/${productId}/move/${uoaId}`), { force: true })),
-    moveTask: (productId, uoaId) =>
-        requests.apiGetRequest(getFullPath(`products/${productId}/move/${uoaId}`)),
+    getTasksByProduct: productId => requests.apiGetRequest(getFullPath(`products/${productId}/tasks`)),
+    forceMoveTask: (productId, uoaId) => requests.apiGetRequest(
+        requests.addQueryParams(getFullPath(`products/${productId}/move/${uoaId}`), { force: true }),
+    ),
+    moveTask: (productId, uoaId) => requests.apiGetRequest(getFullPath(`products/${productId}/move/${uoaId}`)),
     getTaskById: taskId => requests.apiGetRequest(getFullPath(`tasks/${taskId}`)),
     getSelfTasks: () => requests.apiGetRequest(getFullPath('tasks-self')),
     getTasksByUser: userId => requests.apiGetRequest(getFullPath(`tasks-by-user-id/${userId}`)),

--- a/src/services/api/users.js
+++ b/src/services/api/users.js
@@ -3,16 +3,12 @@ import getFullPath from '../../utils/getFullPath';
 
 const users = {
     getProfile: () => requests.apiGetRequest(getFullPath('users/self')),
-    putProfile: requestBody =>
-        requests.apiPutRequest(getFullPath('users/self'), requestBody),
-    putProfileById: (id, requestBody) =>
-        requests.apiPutRequest(getFullPath(`users/${id}`), requestBody),
+    putProfile: requestBody => requests.apiPutRequest(getFullPath('users/self'), requestBody),
+    putProfileById: (id, requestBody) => requests.apiPutRequest(getFullPath(`users/${id}`), requestBody),
     getUsers: () => requests.apiGetRequest(getFullPath('users')),
-    inviteNewUser: requestBody =>
-        requests.apiPostRequest(getFullPath('users/self/organization/invite'), requestBody),
+    inviteNewUser: requestBody => requests.apiPostRequest(getFullPath('users/self/organization/invite'), requestBody),
     deleteUser: id => requests.apiDeleteRequest(getFullPath(`users/${id}`), {}),
-    activate: (requestBody, realm, token) =>
-        requests.apiPostRequest(getFullPath(`users/activate/${token}`, realm), requestBody),
+    activate: (requestBody, realm, token) => requests.apiPostRequest(getFullPath(`users/activate/${token}`, realm), requestBody),
 };
 
 export default users;

--- a/src/utils/Survey.js
+++ b/src/utils/Survey.js
@@ -1,8 +1,8 @@
 import { get, flatten } from 'lodash';
 
 export const questionListLengthFromSurvey = (section) => {
-    return get(section, 'questions.length', 0) +
-        (section.sections || []).reduce(
+    return get(section, 'questions.length', 0)
+        + (section.sections || []).reduce(
             (acc, current) => questionListLengthFromSurvey(current) + acc,
             0,
         );
@@ -12,16 +12,16 @@ export const questionListFromSurvey = (section) => {
     return [
         ...get(section, 'questions', []),
         ...flatten((section.sections || [])
-        .map(sectionIter => questionListFromSurvey(sectionIter))),
+            .map(sectionIter => questionListFromSurvey(sectionIter))),
     ];
 };
 
 export const renderPermissions = (stage) => {
     if (stage.blindReview) {
         return 1;
-    } else if (stage.discussionParticipation) {
+    } if (stage.discussionParticipation) {
         return 2;
-    } else if (stage.allowEdit) {
+    } if (stage.allowEdit) {
         return 3;
     }
     return 0;

--- a/src/utils/TaskStatus.js
+++ b/src/utils/TaskStatus.js
@@ -2,9 +2,9 @@ const day = 24 * 60 * 60 * 1000;
 
 export default {
     responsesComplete(task, surveySize) {
-        return task.response &&
-            task.response.every(response => response.value !== undefined) &&
-                task.response.length === surveySize;
+        return task.response
+            && task.response.every(response => response.value !== undefined)
+                && task.response.length === surveySize;
     },
     endDateInPast(task) {
         return Date.parse(task.endDate) < Date.now();

--- a/src/utils/Time.js
+++ b/src/utils/Time.js
@@ -46,18 +46,18 @@ export default {
     renderEndDateForTaskList(time, vocab) {
         return moment(time).calendar(null, {
             sameDay(now) {
-                return (this.isBefore(now) ?
-                    `[${vocab.TIME.OVERDUE}]` :
-                    `[${vocab.TIME.DUE_TODAY}]`);
+                return (this.isBefore(now)
+                    ? `[${vocab.TIME.OVERDUE}]`
+                    : `[${vocab.TIME.DUE_TODAY}]`);
             },
             nextDay: `[${vocab.TIME.DUE_TOMORROW}]`,
             nextWeek: 'MMM DD Y',
             lastDay: `[${vocab.TIME.OVERDUE}]`,
             lastWeek: `[${vocab.TIME.OVERDUE}]`,
             sameElse(now) {
-                return (this.isBefore(now) ?
-                `[${vocab.TIME.OVERDUE}]` :
-                'MMM DD Y');
+                return (this.isBefore(now)
+                    ? `[${vocab.TIME.OVERDUE}]`
+                    : 'MMM DD Y');
             },
         });
     },

--- a/src/utils/User.js
+++ b/src/utils/User.js
@@ -22,16 +22,16 @@ export const DATA_STATE = {
 
 export const getDataState = (userId, projectId) => {
     return apiService.tasks.getTasksByUser(userId)
-    .then((tasks) => {
-        const statusPromises = (tasks || [])
-        .filter(task => projectId === undefined || task.projectId === projectId)
-        .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId));
+        .then((tasks) => {
+            const statusPromises = (tasks || [])
+                .filter(task => projectId === undefined || task.projectId === projectId)
+                .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId));
 
-        if (statusPromises.length > 0) {
-            return Promise.all(statusPromises)
-            .then(statuses => statuses.some(status => status.status !== 'new'))
-            .then(hasData => (hasData ? DATA_STATE.HAS_DATA : DATA_STATE.HAS_TASKS));
-        }
-        return DATA_STATE.NEITHER;
-    });
+            if (statusPromises.length > 0) {
+                return Promise.all(statusPromises)
+                    .then(statuses => statuses.some(status => status.status !== 'new'))
+                    .then(hasData => (hasData ? DATA_STATE.HAS_DATA : DATA_STATE.HAS_TASKS));
+            }
+            return DATA_STATE.NEITHER;
+        });
 };

--- a/src/utils/Validation.js
+++ b/src/utils/Validation.js
@@ -1,5 +1,5 @@
 export function isValid(rules, value, validateMessages) { // rules as array of rules
-    if (rules.includes('number') && !isNaN(value)) {
+    if (rules.includes('number') && !Number.isNaN(value)) {
         return validateMessages.NUMBER;
     }
     if (rules.includes('letters') && !_isLetters(value)) {

--- a/src/views/Activate/components/index.js
+++ b/src/views/Activate/components/index.js
@@ -39,26 +39,28 @@ class Activate extends Component {
                             apiService.users.activate(
                                 values,
                                 this.props.params.realm,
-                                this.props.params.token)
-                            .then(() => {
-                                toast(this.props.vocab.ACTIVATE.ACTIVATION_SUCCESS,
-                                    { onClose: this.props.redirectToLogin });
-                            })
-                            .catch((err) => {
-                                if (has(ServerErrorsToVocabError, get(err.response, 'status'))) {
-                                    toast(
-                                        this.props.vocab.ERROR[
-                                            ServerErrorsToVocabError[err.response.status]
-                                        ],
-                                        { type: 'error', autoClose: false });
-                                } else {
-                                    toast(this.props.vocab.ERROR.ACTIVATION_FAILURE,
-                                        { type: 'error', autoClose: false });
-                                }
-                            });
+                                this.props.params.token,
+                            )
+                                .then(() => {
+                                    toast(this.props.vocab.ACTIVATE.ACTIVATION_SUCCESS,
+                                        { onClose: this.props.redirectToLogin });
+                                })
+                                .catch((err) => {
+                                    if (has(ServerErrorsToVocabError, get(err.response, 'status'))) {
+                                        toast(
+                                            this.props.vocab.ERROR[
+                                                ServerErrorsToVocabError[err.response.status]
+                                            ],
+                                            { type: 'error', autoClose: false },
+                                        );
+                                    } else {
+                                        toast(this.props.vocab.ERROR.ACTIVATION_FAILURE,
+                                            { type: 'error', autoClose: false });
+                                    }
+                                });
                         }
                     }
-                }/>
+                    }/>
             </div>
         );
     }

--- a/src/views/App.js
+++ b/src/views/App.js
@@ -24,19 +24,19 @@ class App extends Component {
     }
 
     render() { // Check if react-router doesn't have something for this.
-        const subRoot = this.props.location.pathname.substring(0, this.props.location.pathname.indexOf('/', 2)) ||
-            this.props.location.pathname;
+        const subRoot = this.props.location.pathname.substring(0, this.props.location.pathname.indexOf('/', 2))
+            || this.props.location.pathname;
         return (
             <div className='app'>
-                {SECONDARY.includes(subRoot) ?
-                    <SecondaryNavContainer /> :
-                    <PrimaryNavContainer /> }
+                {SECONDARY.includes(subRoot)
+                    ? <SecondaryNavContainer />
+                    : <PrimaryNavContainer /> }
                 <div className='main-body'>
                     {this.props.children}
                 </div>
                 {
-                    this.props.location.pathname !== '/create-new-project' &&
-                    <AmidaFooter
+                    this.props.location.pathname !== '/create-new-project'
+                    && <AmidaFooter
                         versionText={this.props.versionText}
                         footerText={this.props.footerText}/>
                 }

--- a/src/views/CreateProjectWizard/components/AddStages.js
+++ b/src/views/CreateProjectWizard/components/AddStages.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Box } from 'grommet';
+import Box from 'grommet/components/Box';
 import { toast } from 'react-toastify';
 
 import Modal from '../../../common/components/Modal';

--- a/src/views/CreateProjectWizard/components/AddStages.js
+++ b/src/views/CreateProjectWizard/components/AddStages.js
@@ -11,11 +11,12 @@ class AddStages extends Component {
     handleStageDelete(stageId) {
         this.props.actions.wizardShowStageDeleteConfirmModal(stageId);
     }
+
     render() {
         return (<div className='add-stages'>
             {
-                this.props.ui.showAddStage && !this.props.ui.showStageDeleteConfirmModal &&
-                <StageModal vocab={this.props.vocab}
+                this.props.ui.showAddStage && !this.props.ui.showStageDeleteConfirmModal
+                && <StageModal vocab={this.props.vocab}
                     userGroups={this.props.project.userGroups}
                     onCancel={() => this.props.actions.wizardShowStageModal(false)}
                     stageId={this.props.ui.stageEditId}
@@ -27,26 +28,28 @@ class AddStages extends Component {
                             this.props.project,
                             stage,
                             true,
-                            this.props.vocab.ERROR);
+                            this.props.vocab.ERROR,
+                        );
                     }}
                     actions={this.props.actions} />
             }
             {
-                this.props.ui.showStageDeleteConfirmModal &&
-                <Modal title={this.props.vocab.MODAL.STAGE_DELETE_CONFIRM.TITLE}
+                this.props.ui.showStageDeleteConfirmModal
+                && <Modal title={this.props.vocab.MODAL.STAGE_DELETE_CONFIRM.TITLE}
                     bodyText={this.props.vocab.MODAL.STAGE_DELETE_CONFIRM.DELETE_NO_DATA}
                     onCancel={this.props.actions.wizardHideStageDeleteConfirmModal}
                     onSave={() => this.props.actions.wizardDeleteStage(
                         this.props.project.id,
-                        this.props.ui.showStageDeleteConfirmModal.stageId)
-                    .then(() => {
-                        this.props.actions.wizardShowStageModal(false);
-                        this.props.actions.wizardHideStageDeleteConfirmModal();
-                    }).catch(() => {
-                        toast(this.props.vocab.ERROR.STAGE_REQUEST,
-                            { type: 'error', autoClose: false });
-                        this.props.actions.wizardHideStageDeleteConfirmModal();
-                    }) } />
+                        this.props.ui.showStageDeleteConfirmModal.stageId,
+                    )
+                        .then(() => {
+                            this.props.actions.wizardShowStageModal(false);
+                            this.props.actions.wizardHideStageDeleteConfirmModal();
+                        }).catch(() => {
+                            toast(this.props.vocab.ERROR.STAGE_REQUEST,
+                                { type: 'error', autoClose: false });
+                            this.props.actions.wizardHideStageDeleteConfirmModal();
+                        }) } />
             }
             <hr className='divider'/>
             <div className='add-stages__import-row'>
@@ -69,8 +72,8 @@ class AddStages extends Component {
                 })}
 
                 {
-                    this.props.project.stages.length <= 3 &&
-                    <div className='add-stages__grid-row'
+                    this.props.project.stages.length <= 3
+                    && <div className='add-stages__grid-row'
                         onClick={() => this.props.actions.wizardShowStageModal(true)}>
                         <div className='add-stages__grid-row--title'>
                             {this.props.vocab.PROJECT.STAGE_TITLE}

--- a/src/views/CreateProjectWizard/components/AddSubjects/AddSubjectControl.js
+++ b/src/views/CreateProjectWizard/components/AddSubjects/AddSubjectControl.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Field, reduxForm, submit, reset } from 'redux-form';
+import {
+    Field, reduxForm, submit, reset,
+} from 'redux-form';
 import IonIcon from 'react-ionicons';
 
 class AddSubjectControl extends Component {
@@ -45,9 +47,8 @@ export default connect(null, dispatch => ({
     onSubmit: (values, dispatch, ownProps) => {
         ownProps.addSubject(
             ownProps.project,
-            values.subjects.split(/\s*,\s*/).filter(subject =>
-                subject).map((subject) => { return { name: subject }; }),
-                true,
+            values.subjects.split(/\s*,\s*/).filter(subject => subject).map((subject) => { return { name: subject }; }),
+            true,
             ownProps.vocab.ERROR,
         );
     },

--- a/src/views/CreateProjectWizard/components/AddSubjects/index.js
+++ b/src/views/CreateProjectWizard/components/AddSubjects/index.js
@@ -14,37 +14,38 @@ class AddSubjects extends Component {
         this.handleDeleteClick = this.handleDeleteClick.bind(this);
         this.handleModalSave = this.handleModalSave.bind(this);
     }
+
     handleDeleteClick(subjectId) {
         // if used in any other project, do DELETE, otherwise, do disassociate
         apiService.projects.getProjects()
-        .then((projects) => {
-            const deleteType =
-                projects.some(project =>
-                    project.id !== this.props.project.id &&
-                    project.subjects.some(subjectIter => subjectIter.id === subjectId)) ?
-                DELETE_TYPE.DISASSOCIATE_FROM_PROJECT :
-                DELETE_TYPE.DELETE;
-            this.props.actions.wizardShowSubjectDeleteConfirmModal(subjectId, deleteType);
-        })
-        .catch(() => {
-            toast(this.props.vocab.ERROR.SUBJECT_REQUEST, {
-                autoClose: false, type: 'error',
+            .then((projects) => {
+                const deleteType = projects.some(project => project.id !== this.props.project.id
+                    && project.subjects.some(subjectIter => subjectIter.id === subjectId))
+                    ? DELETE_TYPE.DISASSOCIATE_FROM_PROJECT
+                    : DELETE_TYPE.DELETE;
+                this.props.actions.wizardShowSubjectDeleteConfirmModal(subjectId, deleteType);
+            })
+            .catch(() => {
+                toast(this.props.vocab.ERROR.SUBJECT_REQUEST, {
+                    autoClose: false, type: 'error',
+                });
             });
-        });
     }
+
     handleModalSave() {
         if (this.props.ui.showSubjectDeleteConfirmModal.deleteType === DELETE_TYPE.DELETE) {
             apiService.subjects.deleteSubject(this.props.ui.showSubjectDeleteConfirmModal.id)
-            .catch(() => {
-                toast(this.props.vocab.ERROR.SUBJECT_REQUEST,
-                    { autoClose: false, type: 'error' });
-            })
-            .then(() => {
-                this.props.actions.getProjectById(
-                    this.props.project.id,
-                    false,
-                    this.props.vocab.ERROR);
-            });
+                .catch(() => {
+                    toast(this.props.vocab.ERROR.SUBJECT_REQUEST,
+                        { autoClose: false, type: 'error' });
+                })
+                .then(() => {
+                    this.props.actions.getProjectById(
+                        this.props.project.id,
+                        false,
+                        this.props.vocab.ERROR,
+                    );
+                });
             this.props.actions.wizardHideSubjectDeleteConfirmModal();
         } else {
             apiService.projects.deleteUOA(
@@ -52,25 +53,27 @@ class AddSubjects extends Component {
                 {
                     productId: this.props.project.productId,
                     uoaId: this.props.ui.showSubjectDeleteConfirmModal.id,
+                },
+            )
+                .catch(() => {
+                    toast(this.props.vocab.ERROR.SUBJECT_REQUEST,
+                        { autoClose: false, type: 'error' });
                 })
-            .catch(() => {
-                toast(this.props.vocab.ERROR.SUBJECT_REQUEST,
-                    { autoClose: false, type: 'error' });
-            })
-            .then(() => this.props.actions.getProjectById(
-                this.props.project.id,
-                false,
-                this.props.vocab.ERROR),
-            );
+                .then(() => this.props.actions.getProjectById(
+                    this.props.project.id,
+                    false,
+                    this.props.vocab.ERROR,
+                ));
             this.props.actions.wizardHideSubjectDeleteConfirmModal();
         }
     }
+
     render() {
         return (
             <div className='add-subjects'>
                 {
-                    this.props.ui.showSubjectDeleteConfirmModal &&
-                    <Modal title={this.props.vocab.MODAL.SUBJECT_DELETE_CONFIRM.TITLE}
+                    this.props.ui.showSubjectDeleteConfirmModal
+                    && <Modal title={this.props.vocab.MODAL.SUBJECT_DELETE_CONFIRM.TITLE}
                         bodyText={this.props.vocab.MODAL.SUBJECT_DELETE_CONFIRM.SIMPLE_CONFIRM}
                         onCancel={() => this.props.actions.wizardHideSubjectDeletConfirmModal()}
                         onSave={this.handleModalSave}/>
@@ -89,14 +92,12 @@ class AddSubjects extends Component {
                     project={this.props.project}
                     addSubject={this.props.actions.addSubject}
                     vocab={this.props.vocab} />
-                {this.props.project.subjects &&
-                    this.props.project.subjects.map(subject =>
-                    <div className='add-subjects__table-row'
+                {this.props.project.subjects
+                    && this.props.project.subjects.map(subject => <div className='add-subjects__table-row'
                         key={`subject${subject.name}${subject.id}`}>
                         {subject.name}
                         <DeleteIconButton onClick={() => this.handleDeleteClick(subject.id)} />
-                    </div>,
-                )}
+                    </div>)}
             </div>
         );
     }

--- a/src/views/CreateProjectWizard/components/AddSurvey.js
+++ b/src/views/CreateProjectWizard/components/AddSurvey.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { SurveyBuilder } from '../../../views/SurveyBuilder';
+import { SurveyBuilder } from '../../SurveyBuilder';
 
 class AddSurvey extends Component {
     render() {

--- a/src/views/CreateProjectWizard/components/AddUsers/UserGroupsTab.js
+++ b/src/views/CreateProjectWizard/components/AddUsers/UserGroupsTab.js
@@ -15,12 +15,12 @@ class UserGroupsTab extends Component {
 
     handleDeleteClick(groupId) {
         apiService.projects.deleteGroup(groupId)
-        .then(() => {
-            this.props.actions.getProjectById(this.props.projectId, false, this.props.vocab.ERROR);
-        })
-        .catch(() => {
-            toast(this.props.vocab.ERROR.GROUP_DELETE, { autoClose: false, type: 'error' });
-        });
+            .then(() => {
+                this.props.actions.getProjectById(this.props.projectId, false, this.props.vocab.ERROR);
+            })
+            .catch(() => {
+                toast(this.props.vocab.ERROR.GROUP_DELETE, { autoClose: false, type: 'error' });
+            });
     }
 
     filterGroup(group) {
@@ -34,17 +34,17 @@ class UserGroupsTab extends Component {
     render() {
         return (
             <div className='wrapper'>
-            <div className='user-groups-tab'>
-                <Search className='user-groups-tab__search-input'
-                    placeHolder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
-                    fill={true}
-                    inline={true}
-                    onSelect={this.handleSearchSelect}/>
+                <div className='user-groups-tab'>
+                    <Search className='user-groups-tab__search-input'
+                        placeHolder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
+                        fill={true}
+                        inline={true}
+                        onSelect={this.handleSearchSelect}/>
 
-                <UserGroupList groups={this.props.groups.filter(this.filterGroup)}
-                    users={this.props.allUsers}
-                    onDeleteClick={this.handleDeleteClick}/>
-            </div>
+                    <UserGroupList groups={this.props.groups.filter(this.filterGroup)}
+                        users={this.props.allUsers}
+                        onDeleteClick={this.handleDeleteClick}/>
+                </div>
             </div>
 
         );

--- a/src/views/CreateProjectWizard/components/AddUsers/UserGroupsTab.js
+++ b/src/views/CreateProjectWizard/components/AddUsers/UserGroupsTab.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { toast } from 'react-toastify';
-import { Search } from 'grommet';
+import Search from 'grommet/components/Search';
 
 import apiService from '../../../../services/api';
 import UserGroupList from '../../../../common/components/UserGroupList';

--- a/src/views/CreateProjectWizard/components/AddUsers/UsersTab.js
+++ b/src/views/CreateProjectWizard/components/AddUsers/UsersTab.js
@@ -21,7 +21,8 @@ class UsersTab extends Component {
         this.props.actions.addUser(
             selection.value.id,
             this.props.projectId,
-            this.props.vocab.ERROR);
+            this.props.vocab.ERROR,
+        );
     }
 
     handleUserRemove(userId, projectId) {
@@ -41,8 +42,7 @@ class UsersTab extends Component {
                     <UserBadge user={user}/>
                     <div className='users-tab__name'>{renderName(user)}</div>
                 </div>
-                <DeleteIconButton onClick={() =>
-                    this.handleUserRemove(userId, this.props.projectId)} />
+                <DeleteIconButton onClick={() => this.handleUserRemove(userId, this.props.projectId)} />
             </div>
         );
     }
@@ -50,27 +50,29 @@ class UsersTab extends Component {
     render() {
         return (
             <div className='users-tab'>
-            <div className='users-tab__wrapper'>
-                <InviteUserForm vocab={this.props.vocab}
-                    onSubmit={(values) => {
-                        this.props.actions.addNewUser(
-                            values,
-                            this.props.projectId,
-                            this.props.profile.organizationId,
-                            this.props.vocab.TOAST,
-                            this.props.vocab.ERROR);
-                    }} />
-                <div className='users-tab__search'>
-                    <Search
-                        placeHolder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
-                        value={this.props.filter}
-                        list={this.props.allUsers.filter(this.searchFilter)
-                            .map(user => ({ label: renderName(user),
-                                value: user }))}
-                        onChange={evt =>
-                            this.props.actions.addUsersSetUsersFilter(evt.target.value)}
-                        onSelect={this.handleSearchSelect}/>
-                        </div>
+                <div className='users-tab__wrapper'>
+                    <InviteUserForm vocab={this.props.vocab}
+                        onSubmit={(values) => {
+                            this.props.actions.addNewUser(
+                                values,
+                                this.props.projectId,
+                                this.props.profile.organizationId,
+                                this.props.vocab.TOAST,
+                                this.props.vocab.ERROR,
+                            );
+                        }} />
+                    <div className='users-tab__search'>
+                        <Search
+                            placeHolder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
+                            value={this.props.filter}
+                            list={this.props.allUsers.filter(this.searchFilter)
+                                .map(user => ({
+                                    label: renderName(user),
+                                    value: user,
+                                }))}
+                            onChange={evt => this.props.actions.addUsersSetUsersFilter(evt.target.value)}
+                            onSelect={this.handleSearchSelect}/>
+                    </div>
                 </div>
                 <div className='users-tab__user-list'>
                     {this.props.projectUsers.map(this.renderUserEntry)}

--- a/src/views/CreateProjectWizard/components/AddUsers/index.js
+++ b/src/views/CreateProjectWizard/components/AddUsers/index.js
@@ -11,8 +11,8 @@ class AddUsers extends Component {
     render() {
         return (
             <div className='add-users'>
-                {this.props.ui.showSelectGroupUsers &&
-                    <SelectGroupUsers
+                {this.props.ui.showSelectGroupUsers
+                    && <SelectGroupUsers
                         vocab={this.props.vocab}
                         users={this.props.project.users}
                         userGroups={this.props.project.userGroups}
@@ -29,8 +29,8 @@ class AddUsers extends Component {
                         }}/>}
                 <hr className='divider' />
                 <div className='add-users__control-row'>
-                    {this.props.ui.tab === 1 &&
-                        <button className='add-users__control-row-button'
+                    {this.props.ui.tab === 1
+                        && <button className='add-users__control-row-button'
                             onClick={() => this.props.actions.showAddUserGroupWizardModal(true)}>
                             <span>{this.props.vocab.PROJECT.CREATE_USER_GROUP}</span>
                         </button>

--- a/src/views/CreateProjectWizard/components/NewProjectTitle.js
+++ b/src/views/CreateProjectWizard/components/NewProjectTitle.js
@@ -36,15 +36,16 @@ class NewProjectTitle extends Component {
                                 },
                                 langId: 1,
                             },
-                            values.project,
-                        ),
-                        this.props.vocab.ERROR)
-                    .then((project) => {
-                        this.props.actions.postSurvey(
-                            Object.assign({}, this.props.survey, values.survey),
-                            project,
-                            this.props.vocab.ERROR);
-                    });
+                            values.project),
+                        this.props.vocab.ERROR,
+                    )
+                        .then((project) => {
+                            this.props.actions.postSurvey(
+                                Object.assign({}, this.props.survey, values.survey),
+                                project,
+                                this.props.vocab.ERROR,
+                            );
+                        });
                 } }
             vocab={this.props.vocab} />
         </Modal>;

--- a/src/views/CreateProjectWizard/components/NewProjectTitleForm.js
+++ b/src/views/CreateProjectWizard/components/NewProjectTitleForm.js
@@ -29,8 +29,8 @@ class NewProjectTitleForm extends Component {
                         placeholder={this.props.vocab.PROJECT.SUMMARY}
                         className='new-project-title-form__summary' />
                 </div>
-                {this.props.errorMessage &&
-                    <div className='new-project-title-form__error'>
+                {this.props.errorMessage
+                    && <div className='new-project-title-form__error'>
                         {this.props.errorMessage}
                     </div>
                 }

--- a/src/views/CreateProjectWizard/components/WizardComplete.js
+++ b/src/views/CreateProjectWizard/components/WizardComplete.js
@@ -17,9 +17,9 @@ class WizardComplete extends Component {
     }
 
     render() {
-        const surveyComplete = has(this.props.survey, 'id') &&
-            get(this.props.survey, 'sections', []).length > 0 &&
-            this.props.survey.sections.some(section => section.questions.length > 0);
+        const surveyComplete = has(this.props.survey, 'id')
+            && get(this.props.survey, 'sections', []).length > 0
+            && this.props.survey.sections.some(section => section.questions.length > 0);
         return <Modal>
             <div className='wizard-complete'>
                 <h1 className='wizard-complete__header'>

--- a/src/views/CreateProjectWizard/components/WizardFooter.js
+++ b/src/views/CreateProjectWizard/components/WizardFooter.js
@@ -7,7 +7,7 @@ class WizardFooter extends Component {
                 <div>
                     <button className={`wizard-footer__button wizard-footer__button${
                         this.props.step === 0 ? '--disabled' : '--back'}`}
-                        onClick={this.props.onBack}>
+                    onClick={this.props.onBack}>
                         <span>{this.props.vocab.COMMON.GO_BACK}</span>
                     </button>
                 </div>
@@ -23,9 +23,9 @@ class WizardFooter extends Component {
                     <button className='wizard-footer__button wizard-footer__button--continue'
                         onClick={this.props.onContinue}>
                         <span>
-                            {this.props.finalStep ?
-                                this.props.vocab.PROJECT.COMPLETE_PROJECT :
-                                this.props.vocab.COMMON.CONTINUE}
+                            {this.props.finalStep
+                                ? this.props.vocab.PROJECT.COMPLETE_PROJECT
+                                : this.props.vocab.COMMON.CONTINUE}
                         </span>
                     </button>
                 </div>

--- a/src/views/CreateProjectWizard/components/index.js
+++ b/src/views/CreateProjectWizard/components/index.js
@@ -35,15 +35,19 @@ class CreateProjectWizard extends Component {
         this.handleContinue = this.handleContinue.bind(this);
         this.changeStep = this.changeStep.bind(this);
     }
+
     handleBack() {
         this.changeStep(this.props.ui.step - 1);
     }
+
     handleSkip() {
         this.handleContinue();
     }
+
     handleCancel() {
         this.props.onWizardCancel();
     }
+
     handleContinue() {
         if (this.props.ui.step < NUM_WIZARD_STEPS - 1) {
             if (this.props.ui.step === 0) {
@@ -58,10 +62,12 @@ class CreateProjectWizard extends Component {
             this.props.actions.showCompleteWizard(true);
         }
     }
+
     changeStep(step) {
         const newStep = Math.min(Math.max(step, 0), NUM_WIZARD_STEPS);
         this.props.actions.goToStep(newStep);
     }
+
     componentWillMount() {
         this.props.actions.checkProtection(this.props.user.profile)
             .then(() => {
@@ -69,10 +75,11 @@ class CreateProjectWizard extends Component {
                 this.props.actions.projectWizardInitialize();
             });
     }
+
     render() {
-        const surveyComplete = has(this.props.survey, 'id') &&
-            get(this.props.survey, 'sections', []).length > 0 &&
-            this.props.survey.sections.some(section => section.questions.length > 0);
+        const surveyComplete = has(this.props.survey, 'id')
+            && get(this.props.survey, 'sections', []).length > 0
+            && this.props.survey.sections.some(section => section.questions.length > 0);
         const summary = (
             <Summary project={this.props.project}
                 survey={this.props.survey}
@@ -81,10 +88,10 @@ class CreateProjectWizard extends Component {
                 onProjectEditClick={this.props.actions.wizardShowProjectTitleModal}
                 onSurveyEditClick={this.props.actions.wizardShowSurveyTitleModal} />
         );
-        return (!this.props.ui.showComplete ?
-            <div className='project-wizard'>
-                {this.props.ui.showProjectTitle &&
-                    <NewProjectTitle
+        return (!this.props.ui.showComplete
+            ? <div className='project-wizard'>
+                {this.props.ui.showProjectTitle
+                    && <NewProjectTitle
                         profile={this.props.user.profile}
                         errorMessage={this.props.ui.errorMessage}
                         actions={this.props.actions}
@@ -93,15 +100,15 @@ class CreateProjectWizard extends Component {
                         vocab={this.props.vocab} />
                 }
                 {
-                    this.props.ui.showProjectTitleModal &&
-                    <ProjectTitleModal vocab={this.props.vocab}
+                    this.props.ui.showProjectTitleModal
+                    && <ProjectTitleModal vocab={this.props.vocab}
                         actions={this.props.actions}
                         project={this.props.project}
                         onCloseModal={this.props.actions.wizardHideProjectTitleModal} />
                 }
                 {
-                    this.props.ui.showSurveyTitleModal &&
-                    <SurveyTitleModal vocab={this.props.vocab}
+                    this.props.ui.showSurveyTitleModal
+                    && <SurveyTitleModal vocab={this.props.vocab}
                         actions={this.props.actions}
                         survey={this.props.survey}
                         project={this.props.project}
@@ -159,13 +166,13 @@ class CreateProjectWizard extends Component {
                     vocab={this.props.vocab}
                     finalStep={this.props.ui.step === NUM_WIZARD_STEPS - 1}
                     onBack={this.props.ui.step !== 0 ? this.handleBack : undefined}
-                    onSkip={this.props.ui.step < (NUM_WIZARD_STEPS - 1) ?
-                        this.handleSkip : undefined}
+                    onSkip={this.props.ui.step < (NUM_WIZARD_STEPS - 1)
+                        ? this.handleSkip : undefined}
                     step={this.props.ui.step}
                     onCancel={this.handleCancel}
                     onContinue={ this.handleContinue } />
-            </div> :
-            <div className='project-wizard project-wizard--complete'>
+            </div>
+            : <div className='project-wizard project-wizard--complete'>
                 <WizardComplete
                     vocab={this.props.vocab}
                     onWizardComplete={this.props.onWizardComplete}
@@ -191,13 +198,15 @@ CreateProjectWizard.propTypes = {
 };
 
 const mapStateToProps = (store) => {
-    const project = store.wizard.ui.projectLink > 0 ?
-            find(store.projects.data, item => item.id === store.wizard.ui.projectLink) :
-            store.wizard.project;
+    const project = store.wizard.ui.projectLink > 0
+        ? find(store.projects.data, item => item.id === store.wizard.ui.projectLink)
+        : store.wizard.project;
     return {
         project,
-        survey: find(store.surveys.data, survey => survey.id === project.surveyId) ||
-            { id: -1, name: store.surveys.ui.newSurveyName, status: 'draft', sections: [] },
+        survey: find(store.surveys.data, survey => survey.id === project.surveyId)
+            || {
+                id: -1, name: store.surveys.ui.newSurveyName, status: 'draft', sections: [],
+            },
         inProgressSurvey: store.surveybuilder.form,
         user: store.user,
         ui: store.wizard.ui,

--- a/src/views/CreateProjectWizard/reducer.js
+++ b/src/views/CreateProjectWizard/reducer.js
@@ -43,37 +43,54 @@ export default (state = initialState, action) => {
         return initialState;
     case POST_PROJECT_SUCCESS:
         return update(state,
-            { ui: {
-                showProjectTitle: { $set: false },
-                projectLink: { $set: action.project.id },
-                errorMessage: { $set: '' } } });
+            {
+                ui: {
+                    showProjectTitle: { $set: false },
+                    projectLink: { $set: action.project.id },
+                    errorMessage: { $set: '' },
+                },
+            });
     case type.WIZARD_SHOW_STAGE_MODAL: {
         if (action.show) {
-            return update(state, { ui: {
-                showAddStage: { $set: true },
-                stageEditId: { $set: action.stageId },
-            } });
+            return update(state, {
+                ui: {
+                    showAddStage: { $set: true },
+                    stageEditId: { $set: action.stageId },
+                },
+            });
         }
-        return update(state, { ui: {
-            showAddStage: { $set: false },
-            stageEditId: { $set: action.stageId },
-        } });
+        return update(state, {
+            ui: {
+                showAddStage: { $set: false },
+                stageEditId: { $set: action.stageId },
+            },
+        });
     }
     case type.SHOW_ADD_USER_GROUP_WIZARD_MODAL:
-        return update(state, { ui: { addUsers: {
-            showSelectGroupUsers: { $set: action.show },
-        } } });
-    case type.WIZARD_SHOW_SUBJECT_DELETE_CONFIRM_MODAL:
-        return update(state, { ui: {
-            showSubjectDeleteConfirmModal: { $set: {
-                id: action.id,
-                deleteType: action.deleteType },
+        return update(state, {
+            ui: {
+                addUsers: {
+                    showSelectGroupUsers: { $set: action.show },
+                },
             },
-        } });
+        });
+    case type.WIZARD_SHOW_SUBJECT_DELETE_CONFIRM_MODAL:
+        return update(state, {
+            ui: {
+                showSubjectDeleteConfirmModal: {
+                    $set: {
+                        id: action.id,
+                        deleteType: action.deleteType,
+                    },
+                },
+            },
+        });
     case type.WIZARD_HIDE_SUBJECT_DELETE_CONFIRM_MODAL:
-        return update(state, { ui: {
-            showSubjectDeleteConfirmModal: { $set: null },
-        } });
+        return update(state, {
+            ui: {
+                showSubjectDeleteConfirmModal: { $set: null },
+            },
+        });
     case type.GO_TO_STEP:
         return update(state, { ui: { step: { $set: action.step } } });
     case type.SHOW_COMPLETE_WIZARD:
@@ -89,33 +106,47 @@ export default (state = initialState, action) => {
     case REPORT_USER_ERROR:
         return update(state, { ui: { errorMessage: { $set: action.errorMessage } } });
     case type.WIZARD_SHOW_STAGE_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showStageDeleteConfirmModal: { $set: {
-                stageId: action.stageId,
-            } },
-        } });
+        return update(state, {
+            ui: {
+                showStageDeleteConfirmModal: {
+                    $set: {
+                        stageId: action.stageId,
+                    },
+                },
+            },
+        });
     }
     case type.WIZARD_HIDE_STAGE_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showStageDeleteConfirmModal: { $set: null },
-        } });
+        return update(state, {
+            ui: {
+                showStageDeleteConfirmModal: { $set: null },
+            },
+        });
     }
     case type.WIZARD_SHOW_PROJECT_TITLE_MODAL:
-        return update(state, { ui: {
-            showProjectTitleModal: { $set: true },
-        } });
+        return update(state, {
+            ui: {
+                showProjectTitleModal: { $set: true },
+            },
+        });
     case type.WIZARD_HIDE_PROJECT_TITLE_MODAL:
-        return update(state, { ui: {
-            showProjectTitleModal: { $set: false },
-        } });
+        return update(state, {
+            ui: {
+                showProjectTitleModal: { $set: false },
+            },
+        });
     case type.WIZARD_SHOW_SURVEY_TITLE_MODAL:
-        return update(state, { ui: {
-            showSurveyTitleModal: { $set: true },
-        } });
+        return update(state, {
+            ui: {
+                showSurveyTitleModal: { $set: true },
+            },
+        });
     case type.WIZARD_HIDE_SURVEY_TITLE_MODAL:
-        return update(state, { ui: {
-            showSurveyTitleModal: { $set: false },
-        } });
+        return update(state, {
+            ui: {
+                showSurveyTitleModal: { $set: false },
+            },
+        });
     default:
         return state;
     }

--- a/src/views/Login/actions.js
+++ b/src/views/Login/actions.js
@@ -14,37 +14,37 @@ export function login(username, password, realm, referrer, errorMessages) {
             password,
         };
         apiService.auth.login(authPayload)
-        .then((auth) => {
-            dispatch(_loginSuccess(username, auth, realm));
-            apiService.users.getProfile()
-            .then((profileResp) => {
-                dispatch(getProfileSuccess(profileResp));
-                cookie.save('indaba-roleID', profileResp.roleID, { path: '/' });
-                if (referrer) {
-                    dispatch(push(referrer));
-                } else {
-                    dispatch(push(profileResp.roleID === 2 ? '/project' : '/task'));
-                }
+            .then((auth) => {
+                dispatch(_loginSuccess(username, auth, realm));
+                apiService.users.getProfile()
+                    .then((profileResp) => {
+                        dispatch(getProfileSuccess(profileResp));
+                        cookie.save('indaba-roleID', profileResp.roleID, { path: '/' });
+                        if (referrer) {
+                            dispatch(push(referrer));
+                        } else {
+                            dispatch(push(profileResp.roleID === 2 ? '/project' : '/task'));
+                        }
+                    })
+                    .catch(() => {
+                        dispatch(_loginError(errorMessages.SERVER_ISSUE));
+                    });
             })
-            .catch(() => {
-                dispatch(_loginError(errorMessages.SERVER_ISSUE));
+            .catch((err) => {
+                if (err.response) {
+                    dispatch(_loginError(errorMessages.INVALID_LOGIN));
+                } else {
+                    dispatch(_loginError(errorMessages.SERVER_ISSUE));
+                }
+                dispatch(_clearLoginForm());
             });
-        })
-        .catch((err) => {
-            if (err.response) {
-                dispatch(_loginError(errorMessages.INVALID_LOGIN));
-            } else {
-                dispatch(_loginError(errorMessages.SERVER_ISSUE));
-            }
-            dispatch(_clearLoginForm());
-        });
     };
 }
 
 export function requestResetToken(email) {
     return (dispatch) => {
         return apiService.auth.requestResetToken(email)
-        .then(() => dispatch(_requestResetTokenSuccess()));
+            .then(() => dispatch(_requestResetTokenSuccess()));
     };
 }
 

--- a/src/views/Login/components/LoginField.js
+++ b/src/views/Login/components/LoginField.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 class LoginField extends Component {
     render() {
         return (
-                <div className='login-form__field'>
-                    <input className='login-form__input'
-                        {...this.props.input}
-                        type={this.props.type}
-                        placeholder={this.props.placeholder} />
-                        {this.props.input.touched && this.props.input.error
+            <div className='login-form__field'>
+                <input className='login-form__input'
+                    {...this.props.input}
+                    type={this.props.type}
+                    placeholder={this.props.placeholder} />
+                {this.props.input.touched && this.props.input.error
                             && <span>{this.props.input.error}</span>}
-                </div>
+            </div>
         );
     }
 }

--- a/src/views/Login/components/LoginPanel.js
+++ b/src/views/Login/components/LoginPanel.js
@@ -11,8 +11,8 @@ class LoginPanel extends Component {
         return (
             <div className='login-panel'>
                 {
-                    this.props.ui.showForgotPasswordFor &&
-                    <ForgotModal {...this.props}
+                    this.props.ui.showForgotPasswordFor
+                    && <ForgotModal {...this.props}
                         email={this.props.currentEmail}/>
                 }
                 <div className='login-panel__title'>
@@ -26,12 +26,13 @@ class LoginPanel extends Component {
                             values.password,
                             this.props.realm,
                             this.props.ui.timeoutRef,
-                            this.props.vocab.ERROR);
+                            this.props.vocab.ERROR,
+                        );
                     }}/>
-                {(this.props.ui.error || this.props.ui.timeout) &&
-                    <div className='login-panel__error-message'>
-                        {this.props.ui.timeout ?
-                            this.props.vocab.COMMON.TIMEOUT : this.props.ui.error}
+                {(this.props.ui.error || this.props.ui.timeout)
+                    && <div className='login-panel__error-message'>
+                        {this.props.ui.timeout
+                            ? this.props.vocab.COMMON.TIMEOUT : this.props.ui.error}
                     </div>
                 }
                 <div className='login-panel__remember-me'>
@@ -44,15 +45,15 @@ class LoginPanel extends Component {
                                 cookie.remove('indaba-refresh', { path: '/' });
                             }
                         }} />
-                        <span className='login-panel__remember-text'>
-                            {this.props.vocab.COMMON.STAY_LOGGED_IN}
-                        </span>
+                    <span className='login-panel__remember-text'>
+                        {this.props.vocab.COMMON.STAY_LOGGED_IN}
+                    </span>
                 </div>
                 <div className='login-panel__link'
                     onClick={() => (
-                        this.props.currentEmail ?
-                        this.props.actions.showForgotPasswordFor(this.props.currentEmail) :
-                        toast(this.props.vocab.RESET_PASSWORD.EMAIL_REQUIRED)
+                        this.props.currentEmail
+                            ? this.props.actions.showForgotPasswordFor(this.props.currentEmail)
+                            : toast(this.props.vocab.RESET_PASSWORD.EMAIL_REQUIRED)
                     )} >
                     {this.props.vocab.COMMON.FORGOT_PASSWORD}
                 </div>

--- a/src/views/Messages/Inbox/components/Inbox.js
+++ b/src/views/Messages/Inbox/components/Inbox.js
@@ -38,8 +38,7 @@ class Inbox extends Component {
     }
 
     getMessageIdsByThread(originalMessageId) {
-        return this.props.inboxList.find(thread =>
-            thread.originalMessageId === originalMessageId).messageIds;
+        return this.props.inboxList.find(thread => thread.originalMessageId === originalMessageId).messageIds;
     }
 
     handleFilterClick(filter) {
@@ -68,7 +67,7 @@ class Inbox extends Component {
             ).then(this.loadCurrentFilter);
         } else {
             messageAction(id)
-            .then(this.loadCurrentFilter);
+                .then(this.loadCurrentFilter);
         }
     }
 
@@ -79,6 +78,7 @@ class Inbox extends Component {
             this.props.actions.archiveMessage,
         );
     }
+
     handleUnarchive(id) {
         this.handleAction(
             id,
@@ -86,6 +86,7 @@ class Inbox extends Component {
             this.props.actions.unarchiveMessage,
         );
     }
+
     handleDelete(id) {
         this.handleAction(
             id,
@@ -93,6 +94,7 @@ class Inbox extends Component {
             this.props.actions.deleteMessage,
         );
     }
+
     handleMarkAsRead(id) {
         this.handleAction(
             id,
@@ -100,6 +102,7 @@ class Inbox extends Component {
             this.props.actions.markAsRead,
         );
     }
+
     handleMarkAsUnread(id) {
         if (this.props.messages.ui.filter === FILTERS.ALL_MESSAGES) {
             this.props.actions.markAsUnread(
@@ -107,7 +110,7 @@ class Inbox extends Component {
             ).then(this.loadCurrentFilter);
         } else {
             this.props.actions.markAsUnread(id)
-            .then(this.loadCurrentFilter);
+                .then(this.loadCurrentFilter);
         }
     }
 
@@ -178,8 +181,8 @@ class Inbox extends Component {
         const filters = Object.keys(FILTERS).map(key => ({
             key, label: this.props.vocab.MESSAGES.INBOX_FILTER[FILTERS[key]],
         }));
-        const noNext = this.props.messages.inboxCount <=
-            (INBOX_COUNT * (this.props.messages.inboxPage + 1));
+        const noNext = this.props.messages.inboxCount
+            <= (INBOX_COUNT * (this.props.messages.inboxPage + 1));
         const noPrevious = this.props.messages.inboxPage === 0;
         return (
             <div className='inbox'>
@@ -215,21 +218,21 @@ class Inbox extends Component {
                 <div className='inbox__pager'>
                     <div className='inbox__pager-content'>
                         {
-                            !noPrevious &&
-                            <button className={'inbox__pager-button'}
+                            !noPrevious
+                            && <button className={'inbox__pager-button'}
                                 onClick={this.handlePrevious}>
                                 {this.props.vocab.MESSAGES.PREVIOUS}
                             </button>
                         }
                         {
-                            (this.props.messages.inboxPage !== 0 || !noNext) &&
-                            <div className='inbox__page'>
+                            (this.props.messages.inboxPage !== 0 || !noNext)
+                            && <div className='inbox__page'>
                                 {this.props.messages.inboxPage + 1}
                             </div>
                         }
                         {
-                            !noNext &&
-                            <button className={'inbox__pager-button'}
+                            !noNext
+                            && <button className={'inbox__pager-button'}
                                 onClick={this.handleNext}>
                                 {this.props.vocab.MESSAGES.NEXT}
                             </button>

--- a/src/views/Messages/Inbox/components/InboxMessageList.js
+++ b/src/views/Messages/Inbox/components/InboxMessageList.js
@@ -24,8 +24,7 @@ class InboxMessageList extends Component {
         return (
             <div key={actionId}
                 className='inbox-message-list__entry'
-                onClick={() =>
-                    this.props.onMessageClick(this.props.thread ? entry.refMessageId : entry.id)}>
+                onClick={() => this.props.onMessageClick(this.props.thread ? entry.refMessageId : entry.id)}>
                 <div className='inbox-message-list__from'>
                     <div className={`inbox-message-list__unread-indicator ${entry.unread ? 'inbox-message-list__unread-indicator--unread' : ''}`} />
                     {this.renderFrom(entry.from)}
@@ -41,8 +40,8 @@ class InboxMessageList extends Component {
                     <div className={`inbox-message-list__unread-indicator ${entry.unread ? 'inbox-message-list__unread-indicator--unread' : ''}`} />
                     <ButtonPanel>
                         {
-                            !entry.isArchived &&
-                            <PanelButton title={this.props.vocab.MESSAGES.ARCHIVE}
+                            !entry.isArchived
+                            && <PanelButton title={this.props.vocab.MESSAGES.ARCHIVE}
                                 onClick={
                                     (event) => {
                                         this.props.onArchive(actionId);
@@ -54,8 +53,8 @@ class InboxMessageList extends Component {
                             </PanelButton>
                         }
                         {
-                            !entry.isArchived && entry.unread &&
-                            <PanelButton
+                            !entry.isArchived && entry.unread
+                            && <PanelButton
                                 title={this.props.vocab.MESSAGES.MARK_AS_READ}
                                 onClick={
                                     (event) => {
@@ -68,8 +67,8 @@ class InboxMessageList extends Component {
                             </PanelButton>
                         }
                         {
-                            !entry.isArchived && !entry.unread &&
-                            <PanelButton
+                            !entry.isArchived && !entry.unread
+                            && <PanelButton
                                 title={this.props.vocab.MESSAGES.MARK_AS_UNREAD}
                                 onClick={
                                     (event) => {
@@ -82,8 +81,8 @@ class InboxMessageList extends Component {
                             </PanelButton>
                         }
                         {
-                            entry.isArchived &&
-                            <PanelButton
+                            entry.isArchived
+                            && <PanelButton
                                 title={this.props.vocab.MESSAGES.RETURN_TO_INBOX}
                                 onClick={
                                     (event) => {
@@ -96,8 +95,8 @@ class InboxMessageList extends Component {
                             </PanelButton>
                         }
                         {
-                            entry.isArchived &&
-                            <PanelButton
+                            entry.isArchived
+                            && <PanelButton
                                 onClick={
                                     (event) => {
                                         this.props.onDelete(actionId);
@@ -113,6 +112,7 @@ class InboxMessageList extends Component {
             </div>
         );
     }
+
     render() {
         return (
             <div className='inbox-message-list'>
@@ -130,8 +130,8 @@ class InboxMessageList extends Component {
                     </div>
                 </div>
                 {this.props.entries.map(this.renderEntry)}
-                {this.props.entries.length === 0 &&
-                    <div className='inbox-message-list__entry inbox-message-list__entry--empty'>
+                {this.props.entries.length === 0
+                    && <div className='inbox-message-list__entry inbox-message-list__entry--empty'>
                         {this.props.vocab.MESSAGES.NO_MESSAGES}
                     </div>
                 }

--- a/src/views/Messages/Inbox/components/InboxTabs.js
+++ b/src/views/Messages/Inbox/components/InboxTabs.js
@@ -22,16 +22,14 @@ class InboxTabs extends Component {
         return (
             <div className='inbox-tabs'>
                 {
-                    Object.keys(tabs).map(key =>
-                        <div key={key}
-                            className={`inbox-tabs__tab ${this.props.active === key ? 'inbox-tabs__tab--active' : ''}`}
-                            onClick={() => this.props.onSelectTab(key)} >
-                            {tabs[key].icon()}
-                            <div className='inbox-tabs__label'>
-                                {tabs[key].title}
-                            </div>
-                        </div>,
-                    )
+                    Object.keys(tabs).map(key => <div key={key}
+                        className={`inbox-tabs__tab ${this.props.active === key ? 'inbox-tabs__tab--active' : ''}`}
+                        onClick={() => this.props.onSelectTab(key)} >
+                        {tabs[key].icon()}
+                        <div className='inbox-tabs__label'>
+                            {tabs[key].title}
+                        </div>
+                    </div>)
                 }
             </div>
         );

--- a/src/views/Messages/Message/components/CollapsedMessage.js
+++ b/src/views/Messages/Message/components/CollapsedMessage.js
@@ -16,8 +16,9 @@ class CollapsedMessage extends Component {
                     {this.props.vocab.MESSAGES.FROM}{': '}
                     {_.get(this.props, 'message.from')}
                     <div className='collapsed-message__timestamp'>
-                    {this.props.message && Time.renderForMessage(
-                        this.props.message.createdAt, this.props.vocab)}
+                        {this.props.message && Time.renderForMessage(
+                            this.props.message.createdAt, this.props.vocab,
+                        )}
                     </div>
                 </div>
                 <div className='collapsed-message__body'>

--- a/src/views/Messages/Message/components/Message.js
+++ b/src/views/Messages/Message/components/Message.js
@@ -22,20 +22,20 @@ class Message extends Component {
         const systemMessage = _.get(this.props, 'message.systemMessage', false);
         const unread = _.get(this.props, 'message.unread');
 
-        if (!compose && !active &&
-            !this.props.ui.expandedMessages.includes(_.get(this.props, 'message.id'))) {
+        if (!compose && !active
+            && !this.props.ui.expandedMessages.includes(_.get(this.props, 'message.id'))) {
             return <CollapsedMessage {...this.props}
                 message={
-                    this.props.message &&
-                    Object.assign({}, this.props.message, {
+                    this.props.message
+                    && Object.assign({}, this.props.message, {
                         from: renderNameByEmail(this.props.message.from, this.props.users),
                     })
                 }/>;
         }
         return (
             <div className={`message ${active ? 'message--active' : ''} ${compose ? 'message--compose' : ''}`}
-                onClick={() => !compose && !active &&
-                    this.props.goToMessage(this.props.id)}>
+                onClick={() => !compose && !active
+                    && this.props.goToMessage(this.props.id)}>
                 <form className='message__content' onSubmit={this.props.handleSubmit}>
                     <div className='message__row message__row--to'>
                         <MessageField label={this.props.vocab.MESSAGES.TO}
@@ -52,16 +52,17 @@ class Message extends Component {
                             name='to'/>
                         <div className='message__timestamp'>
                             {this.props.message && Time.renderForMessage(
-                                this.props.message.createdAt, this.props.vocab)}
+                                this.props.message.createdAt, this.props.vocab,
+                            )}
                         </div>
                     </div>
                     <div className='message__row'>
                         <MessageField label={this.props.vocab.MESSAGES.FROM}
                             input={false}
                             value={
-                                compose ?
-                                renderName(this.props.profile) :
-                                renderNameByEmail(_.get(this.props, 'message.from'), this.props.users)
+                                compose
+                                    ? renderName(this.props.profile)
+                                    : renderNameByEmail(_.get(this.props, 'message.from'), this.props.users)
                             }
                             name='from'/>
                     </div>
@@ -73,32 +74,32 @@ class Message extends Component {
                     </div>
                     <div className='message__body-section'>
                         {
-                            !compose &&
-                            <div className='message__body-actions'>
+                            !compose
+                            && <div className='message__body-actions'>
                                 <ButtonPanel>
                                     {
-                                        !unread &&
-                                        <PanelButton
+                                        !unread
+                                        && <PanelButton
                                             title={this.props.vocab.MESSAGES.MARK_AS_UNREAD}
                                             onClick={() => this.props.actions
-                                                    .markAsUnread(this.props.message.id)}>
+                                                .markAsUnread(this.props.message.id)}>
                                             <IonIcon icon='ion-email-unread'
                                                 className='message__action-icon'/>
                                         </PanelButton>
                                     }
                                     {
-                                        unread &&
-                                        <PanelButton
+                                        unread
+                                        && <PanelButton
                                             title={this.props.vocab.MESSAGES.MARK_AS_READ}
                                             onClick={() => this.props.actions
-                                                    .markAsRead(this.props.message.id)}>
+                                                .markAsRead(this.props.message.id)}>
                                             <IonIcon icon='ion-ios-checkmark-empty'
                                                 className='message__action-icon'/>
                                         </PanelButton>
                                     }
                                     {
-                                        !systemMessage &&
-                                        <PanelButton
+                                        !systemMessage
+                                        && <PanelButton
                                             onClick={() => this.props.actions
                                                 .forwardMessage(this.props.message) }>
                                             <IonIcon icon='ion-arrow-right-a'
@@ -110,15 +111,15 @@ class Message extends Component {
                                             <PanelButton key='reply-button'
                                                 onClick={() => this.props.actions
                                                     .startReply(this.props.message) }>
-                                                    <IonIcon icon='ion-reply'
-                                                        className='message__action-icon'/>
-                                                </PanelButton>,
+                                                <IonIcon icon='ion-reply'
+                                                    className='message__action-icon'/>
+                                            </PanelButton>,
                                             <PanelButton key='reply-all-button'
                                                 onClick={() => this.props.actions
                                                     .startReplyAll(this.props.message) }>
-                                                    <IonIcon icon='ion-reply-all'
-                                                        className='message__action-icon'/>
-                                                </PanelButton>,
+                                                <IonIcon icon='ion-reply-all'
+                                                    className='message__action-icon'/>
+                                            </PanelButton>,
                                         ]
                                     }
                                 </ButtonPanel>
@@ -131,8 +132,8 @@ class Message extends Component {
                                 name='message'/>
                         </div>
                         {
-                            compose &&
-                            <div className='message__body-buttons'>
+                            compose
+                            && <div className='message__body-buttons'>
                                 <button className='message__body-cancel-button'
                                     onClick={this.props.onCancel}>
                                     <span>{this.props.vocab.COMMON.CANCEL}</span>
@@ -146,8 +147,8 @@ class Message extends Component {
                     </div>
                 </form>
                 {
-                    !compose && received && !systemMessage &&
-                    <div className='message__inline-reply'
+                    !compose && received && !systemMessage
+                    && <div className='message__inline-reply'
                         onClick={(evt) => {
                             this.props.actions.startReplyAll(this.props.message);
                             evt.stopPropagation();
@@ -177,6 +178,7 @@ class MessageSelector extends Component {
         this.cancelForm = this.cancelForm.bind(this);
         this.handleSendResponse = this.handleSendResponse.bind(this);
     }
+
     submitForm(values) {
         const reply = this.props.reply || _.get(this.props, 'location.state.message');
         const message = {
@@ -187,12 +189,13 @@ class MessageSelector extends Component {
         };
         if (_.has(reply, 'id')) {
             apiService.messaging.reply(reply.id, message)
-            .then(this.handleSendResponse);
+                .then(this.handleSendResponse);
         } else {
             apiService.messaging.send(message)
-            .then(this.handleSendResponse);
+                .then(this.handleSendResponse);
         }
     }
+
     cancelForm() {
         const reply = this.props.reply || _.get(this.props, 'location.state.message');
         if (_.has(reply, 'id') || _.has(reply, 'forwardId')) {
@@ -201,11 +204,13 @@ class MessageSelector extends Component {
             this.props.goToInbox();
         }
     }
+
     handleSendResponse(result) {
         this.props.actions.discardReply();
         this.props.actions.getThreadContainingMessage(result.id);
         this.props.goToMessage(result.id);
     }
+
     render() {
         if (this.props.id !== undefined) {
             return (<Message {...this.props} />);

--- a/src/views/Messages/Message/components/MessageBodyField.js
+++ b/src/views/Messages/Message/components/MessageBodyField.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 
-const inputComponent = ({ input, meta: { touched, error } }) =>
-(
+const inputComponent = ({ input, meta: { touched, error } }) => (
     <textarea className={`message-body-field__value ${(touched && error) ? 'message-body-field__value--error' : ''}`}
         autoFocus
         {...input}/>
@@ -14,12 +13,12 @@ class MessageBodyField extends Component {
         return (
             <div className='message-body-field'>
                 {
-                    this.props.input ?
-                    <Field component={inputComponent}
-                        name={this.props.name}/> :
-                    <div className='message-body-field__value'>
-                        {this.props.value}
-                    </div>
+                    this.props.input
+                        ? <Field component={inputComponent}
+                            name={this.props.name}/>
+                        : <div className='message-body-field__value'>
+                            {this.props.value}
+                        </div>
                 }
             </div>
         );

--- a/src/views/Messages/Message/components/MessageField.js
+++ b/src/views/Messages/Message/components/MessageField.js
@@ -2,8 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Field } from 'redux-form';
 
-const inputComponent = ({ input, meta: { touched, error } }) =>
-(
+const inputComponent = ({ input, meta: { touched, error } }) => (
     <input className={`message-field__value ${(touched && error) ? 'message-field__value--error' : ''}`}
         {...input}/>
 );
@@ -14,16 +13,16 @@ class MessageField extends Component {
             <div className='message-field'>
                 <div className='message-field__label'>{this.props.label}: </div>
                 {
-                    this.props.input ?
-                    <Field component={
-                            this.props.component ||
-                            inputComponent
+                    this.props.input
+                        ? <Field component={
+                            this.props.component
+                            || inputComponent
                         }
                         {...this.props.componentProps}
-                        name={this.props.name}/> :
-                    <div className='message-field__value'>
-                        {this.props.value}
-                    </div>
+                        name={this.props.name}/>
+                        : <div className='message-field__value'>
+                            {this.props.value}
+                        </div>
                 }
             </div>
         );

--- a/src/views/Messages/Message/components/ToField.js
+++ b/src/views/Messages/Message/components/ToField.js
@@ -35,7 +35,7 @@ class ToField extends Component {
     }
 
     handleUpdateToQuery(event) {
-        this.props.actions.setToQuery(evt.target.value);
+        this.props.actions.setToQuery(event.target.value);
     }
 
     render() {
@@ -59,7 +59,7 @@ class ToField extends Component {
                         }
                         onBlur={() => this.props.input.onBlur(this.props.input.value)}
                         onChange={this.handleUpdateToQuery}
-                        onSelect={selection => this.handleSelect(selection, this.props.meta.dispatch)}
+                        onSelect={this.handleSelect}
                     />
                     {
                         this.props.meta.touched && this.props.meta.error

--- a/src/views/Messages/Message/components/ToField.js
+++ b/src/views/Messages/Message/components/ToField.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Search } from 'grommet';
+import Search from 'grommet/components/Search';
 import _ from 'lodash';
 
 import { renderName } from '../../../../utils/User';

--- a/src/views/Messages/Message/components/ToField.js
+++ b/src/views/Messages/Message/components/ToField.js
@@ -14,19 +14,25 @@ class ToField extends Component {
         this.handleSelect = this.handleSelect.bind(this);
         this.handleRemove = this.handleRemove.bind(this);
     }
+
     searchFilter(user) {
         return !this.props.input.value.includes(user.email);
     }
+
     handleSelect(selection) {
         this.props.input.onChange(_.union(this.props.input.value,
             [selection.suggestion.value.email]));
         this.props.actions.setToQuery('');
     }
+
     handleRemove(email) {
         this.props.input.onChange(
             this.props.input.value.filter(
-                emailIter => emailIter !== email));
+                emailIter => emailIter !== email,
+            ),
+        );
     }
+
     render() {
         const submitFailed = this.props.meta.submitFailed;
         const touched = this.props.meta.touched;
@@ -41,23 +47,22 @@ class ToField extends Component {
                         value={this.props.query}
                         onBlur={() => this.props.input.onBlur(this.props.input.value)}
                         suggestions=
-                        {
-                            this.props.users
-                            .filter(this.searchFilter)
-                            .filter(user => renderName(user).toLowerCase()
-                                .includes(this.props.query.toLowerCase()))
-                            .map(user => ({ label: renderName(user), value: user }))
-                        }
-                        onSelect={selection =>
-                            this.handleSelect(selection, this.props.meta.dispatch)}
+                            {
+                                this.props.users
+                                    .filter(this.searchFilter)
+                                    .filter(user => renderName(user).toLowerCase()
+                                        .includes(this.props.query.toLowerCase()))
+                                    .map(user => ({ label: renderName(user), value: user }))
+                            }
+                        onSelect={selection => this.handleSelect(selection, this.props.meta.dispatch)}
                     />
                     {
                         this.props.meta.touched && this.props.meta.error
                     }
                 </div>
                 {
-                    this.props.input.value !== '' &&
-                    this.props.input.value.map(email => (
+                    this.props.input.value !== ''
+                    && this.props.input.value.map(email => (
                         <Addressee key={email} email={email} users={this.props.users}
                             onRemove={this.handleRemove}/>
                     ))

--- a/src/views/Messages/Message/components/index.js
+++ b/src/views/Messages/Message/components/index.js
@@ -18,6 +18,7 @@ class MessageContainer extends Component {
             this.props.actions.expandMessages([this.props.id]);
         }
     }
+
     render() {
         return (
             <div className='message-container'>
@@ -31,28 +32,26 @@ class MessageContainer extends Component {
                 {
                     (() => {
                         if (this.props.id !== undefined) {
-                            const elements = this.props.thread.map(message =>
-                                <Message {...this.props}
-                                    key={message.id}
-                                    id={message.id}
-                                    message={message} />,
-                            );
+                            const elements = this.props.thread.map(message => <Message {...this.props}
+                                key={message.id}
+                                id={message.id}
+                                message={message} />);
 
                             const insertAfterId = get(this.props, 'ui.reply.id',
                                 get(this.props, 'ui.reply.forwardId'));
                             if (this.props.ui.reply) {
                                 elements.splice(
-                                    this.props.thread.findIndex(messageIter =>
-                                        messageIter.id === insertAfterId) + 1,
-                                        0,
-                                        <Message key='reply'
-                                            vocab={this.props.vocab}
-                                            profile={this.props.profile}
-                                            reply={this.props.ui.reply}
-                                            actions={this.props.actions}
-                                            users={this.props.users}
-                                            ui={this.props.ui}
-                                            goToMessage={this.props.goToMessage}/>);
+                                    this.props.thread.findIndex(messageIter => messageIter.id === insertAfterId) + 1,
+                                    0,
+                                    <Message key='reply'
+                                        vocab={this.props.vocab}
+                                        profile={this.props.profile}
+                                        reply={this.props.ui.reply}
+                                        actions={this.props.actions}
+                                        users={this.props.users}
+                                        ui={this.props.ui}
+                                        goToMessage={this.props.goToMessage}/>,
+                                );
                             }
                             return elements;
                         }
@@ -65,9 +64,9 @@ class MessageContainer extends Component {
 }
 
 const mapStateToProps = (store, ownProps) => {
-    const id = ownProps.params.id !== undefined ?
-        parseInt(ownProps.params.id, 10) :
-        undefined;
+    const id = ownProps.params.id !== undefined
+        ? parseInt(ownProps.params.id, 10)
+        : undefined;
     return {
         id,
         thread: store.messages.thread,

--- a/src/views/Messages/actions.js
+++ b/src/views/Messages/actions.js
@@ -22,30 +22,22 @@ export const setToQuery = query => ({
     query,
 });
 
-export const archiveThread = ids => () =>
-    Promise.all(ids.map(id => apiService.messaging.archive(id)));
+export const archiveThread = ids => () => Promise.all(ids.map(id => apiService.messaging.archive(id)));
 
-export const unarchiveThread = ids => () =>
-    Promise.all(ids.map(id => apiService.messaging.unarchive(id)));
+export const unarchiveThread = ids => () => Promise.all(ids.map(id => apiService.messaging.unarchive(id)));
 
-export const markThreadAsRead = ids => () =>
-    Promise.all(ids.map(id => apiService.messaging.markAsRead(id)));
+export const markThreadAsRead = ids => () => Promise.all(ids.map(id => apiService.messaging.markAsRead(id)));
 
-export const deleteThread = ids => () =>
-    Promise.all(ids.map(id => apiService.messaging.delete(id)));
+export const deleteThread = ids => () => Promise.all(ids.map(id => apiService.messaging.delete(id)));
 
-export const archiveMessage = id => () =>
-    apiService.messaging.archive(id);
+export const archiveMessage = id => () => apiService.messaging.archive(id);
 
-export const unarchiveMessage = id => () =>
-    apiService.messaging.unarchive(id);
+export const unarchiveMessage = id => () => apiService.messaging.unarchive(id);
 
-export const markAsUnread = id => dispatch =>
-    apiService.messaging.markAsUnread(id)
+export const markAsUnread = id => dispatch => apiService.messaging.markAsUnread(id)
     .then(response => dispatch(_putMessageSuccess(response)));
 
-export const deleteMessage = id => () =>
-    apiService.messaging.delete(id);
+export const deleteMessage = id => () => apiService.messaging.delete(id);
 
 
 const _putMessageSuccess = message => ({
@@ -54,32 +46,28 @@ const _putMessageSuccess = message => ({
     id: message.id,
 });
 
-export const markAsRead = id => dispatch =>
-    apiService.messaging.markAsRead(id)
+export const markAsRead = id => dispatch => apiService.messaging.markAsRead(id)
     .then(response => dispatch(_putMessageSuccess(response)));
 
-export const startReply = message =>
-    _startReply({
-        id: message.id,
-        subject: message.subject,
-        to: [message.from],
-        from: message.owner,
-    });
+export const startReply = message => _startReply({
+    id: message.id,
+    subject: message.subject,
+    to: [message.from],
+    from: message.owner,
+});
 
-export const startReplyAll = message =>
-    _startReply({
-        id: message.id,
-        subject: message.subject,
-        to: [message.from, ...message.to].filter(recipient => recipient !== message.owner),
-        from: message.owner,
-    });
+export const startReplyAll = message => _startReply({
+    id: message.id,
+    subject: message.subject,
+    to: [message.from, ...message.to].filter(recipient => recipient !== message.owner),
+    from: message.owner,
+});
 
-export const forwardMessage = message =>
-    _startReply({
-        forwardId: message.id,
-        subject: message.subject,
-        from: message.to,
-    });
+export const forwardMessage = message => _startReply({
+    forwardId: message.id,
+    subject: message.subject,
+    from: message.to,
+});
 
 export const discardReply = () => ({
     type: actionTypes.DISCARD_REPLY,
@@ -100,22 +88,19 @@ export const setInboxPage = page => ({
     page,
 });
 
-export const getInboxMessages = params => dispatch =>
-    apiService.messaging.list(params)
+export const getInboxMessages = params => dispatch => apiService.messaging.list(params)
     .then(result => dispatch(_getInboxMessagesSuccess(result)));
 
-export const getThreadContainingMessage = messageId => dispatch =>
-    apiService.messaging.get(messageId)
+export const getThreadContainingMessage = messageId => dispatch => apiService.messaging.get(messageId)
     .then(messageResponse => dispatch(getThread(messageResponse.originalMessageId)));
 
 export const getThread = originalMessageId => (dispatch) => {
     dispatch(_getThread());
     return apiService.messaging.getThread(originalMessageId)
-    .then(response => dispatch(_getThreadSuccess(response)));
+        .then(response => dispatch(_getThreadSuccess(response)));
 };
 
-export const getInboxThreads = params => dispatch =>
-    apiService.messaging.listThreads(params)
+export const getInboxThreads = params => dispatch => apiService.messaging.listThreads(params)
     .then(response => dispatch(_getInboxThreadsSuccess(response)));
 
 /* Private actions */

--- a/src/views/Messages/components/ButtonPanel.js
+++ b/src/views/Messages/components/ButtonPanel.js
@@ -6,8 +6,8 @@ export class PanelButton extends Component {
         return (
             <div className='button-panel__button' {...this.props}
                 onClick={
-                    this.props.onClick &&
-                    ((evt) => {
+                    this.props.onClick
+                    && ((evt) => {
                         evt.stopPropagation();
                         this.props.onClick(evt);
                     })

--- a/src/views/Messages/reducer.js
+++ b/src/views/Messages/reducer.js
@@ -20,11 +20,10 @@ const initialState = {
     inboxPage: 0,
 };
 
-const transformServerMessageToReduxMessage = message =>
-    Object.assign(message, {
-        systemMessage: message.from === config.SYS_MESSAGE_USER,
-        unread: message.readAt === null,
-    });
+const transformServerMessageToReduxMessage = message => Object.assign(message, {
+    systemMessage: message.from === config.SYS_MESSAGE_USER,
+    unread: message.readAt === null,
+});
 
 export default (state = initialState, action) => {
     const threadIndex = state.thread.findIndex(message => message.id === action.id);
@@ -41,32 +40,42 @@ export default (state = initialState, action) => {
     case actionTypes.SET_INBOX_PAGE:
         return update(state, { inboxPage: { $set: action.page } });
     case actionTypes.START_REPLY:
-        return update(state, { ui: {
-            reply: { $set: action.reply },
-        } });
-    case actionTypes.DISCARD_REPLY:
-        return update(state, { ui: {
-            reply: { $set: false },
-        } });
-    case actionTypes.PUT_MESSAGE_SUCCESS:
-        return threadIndex === -1 ?
-        state :
-        update(state, { thread:
-            { [threadIndex]: { $set: transformServerMessageToReduxMessage(action.message) } },
+        return update(state, {
+            ui: {
+                reply: { $set: action.reply },
+            },
         });
+    case actionTypes.DISCARD_REPLY:
+        return update(state, {
+            ui: {
+                reply: { $set: false },
+            },
+        });
+    case actionTypes.PUT_MESSAGE_SUCCESS:
+        return threadIndex === -1
+            ? state
+            : update(state, {
+                thread:
+            { [threadIndex]: { $set: transformServerMessageToReduxMessage(action.message) } },
+            });
     case actionTypes.EXPAND_MESSAGES:
-        return update(state, { ui: {
-            expandedMessages: { $push: action.messageIds },
-        } });
+        return update(state, {
+            ui: {
+                expandedMessages: { $push: action.messageIds },
+            },
+        });
     case actionTypes.SET_EXPANDED_MESSAGES:
-        return update(state, { ui: {
-            expandedMessages: { $set: action.messageIds },
-        } });
+        return update(state, {
+            ui: {
+                expandedMessages: { $set: action.messageIds },
+            },
+        });
     case actionTypes.GET_THREAD_SUCCESS:
         return update(state, {
-            thread: { $set:
+            thread: {
+                $set:
                 sortBy(action.thread, 'createdAt').reverse()
-                .map(transformServerMessageToReduxMessage),
+                    .map(transformServerMessageToReduxMessage),
             },
         });
     case actionTypes.GET_INBOX_THREADS_SUCCESS:

--- a/src/views/PMAllSubjects/actions.js
+++ b/src/views/PMAllSubjects/actions.js
@@ -19,8 +19,8 @@ export const pmAllSubjectsShowDeleteConfirmModal = (id, confirmType) => ({
 export const pmAllSubjectsGetSubjects = () => (dispatch) => {
     dispatch(_getSubjects());
     subjectsApi.getSubjects()
-    .then(response => dispatch(_getSubjectsSuccess(response)))
-    .catch(err => dispatch(_getSubjectsError(err)));
+        .then(response => dispatch(_getSubjectsSuccess(response)))
+        .catch(err => dispatch(_getSubjectsError(err)));
 };
 
 const _getSubjects = () => ({
@@ -48,8 +48,8 @@ export const pmAllSubjectsOrderByNameDescending = () => ({
 export const pmAllSubjectsDeleteSubject = id => (dispatch) => {
     dispatch(_deleteSubject());
     subjectsApi.deleteSubject(id)
-    .then(response => dispatch(_deleteSubjectSuccess(response)))
-    .catch(err => dispatch(_deleteSubjectError(err)));
+        .then(response => dispatch(_deleteSubjectSuccess(response)))
+        .catch(err => dispatch(_deleteSubjectError(err)));
 };
 
 const _deleteSubject = () => ({

--- a/src/views/PMAllSubjects/components/PMAllSubjects.js
+++ b/src/views/PMAllSubjects/components/PMAllSubjects.js
@@ -13,75 +13,82 @@ class PMAllSubjects extends Component {
         super(props);
         this.attemptSubjectDelete = this.attemptSubjectDelete.bind(this);
     }
+
     subjectRequestToast() {
         toast(this.props.vocab.ERROR.SUBJECT_REQUEST,
-            { autoClose: false, type: 'error' },
-        );
+            { autoClose: false, type: 'error' });
     }
+
     subjectHasData(subjectId) {
         return apiService.tasks.getTasks()
-        .then((tasks) => {
-            const answerPromises = tasks
-            .filter(task => task.uoaId === subjectId)
-            .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId));
+            .then((tasks) => {
+                const answerPromises = tasks
+                    .filter(task => task.uoaId === subjectId)
+                    .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId));
 
-            return Promise.all(answerPromises)
-            .then(statuses => statuses.some(status => status.status !== 'new'));
-        });
+                return Promise.all(answerPromises)
+                    .then(statuses => statuses.some(status => status.status !== 'new'));
+            });
     }
+
     attemptSubjectDelete(subject) {
         apiService.projects.getProjects()
-        .then((projects) => {
-            if (!projects.some(project => project.subjects.some(
+            .then((projects) => {
+                if (!projects.some(project => project.subjects.some(
                     subjectIter => subjectIter.id === subject.id,
                 ))) {
-                return this.props.actions.pmAllSubjectsShowDeleteConfirmModal(
-                    subject.id,
-                    CONFIRM_TYPE.SIMPLE);
-            }
-            return this.subjectHasData(subject.id)
-                .then((hasData) => {
-                    if (!hasData) {
-                        this.props.actions.pmAllSubjectsShowDeleteConfirmModal(
-                            subject.id,
-                            CONFIRM_TYPE.ASSOCIATED_PROJECT);
-                    } else {
-                        toast(this.props.vocab.ERROR.NO_DELETE_SUBJECT_WITH_DATA,
-                            { autoClose: false, type: 'error' });
-                    }
-                });
-        })
-        .catch(this.subjectRequestToast);
+                    return this.props.actions.pmAllSubjectsShowDeleteConfirmModal(
+                        subject.id,
+                        CONFIRM_TYPE.SIMPLE,
+                    );
+                }
+                return this.subjectHasData(subject.id)
+                    .then((hasData) => {
+                        if (!hasData) {
+                            this.props.actions.pmAllSubjectsShowDeleteConfirmModal(
+                                subject.id,
+                                CONFIRM_TYPE.ASSOCIATED_PROJECT,
+                            );
+                        } else {
+                            toast(this.props.vocab.ERROR.NO_DELETE_SUBJECT_WITH_DATA,
+                                { autoClose: false, type: 'error' });
+                        }
+                    });
+            })
+            .catch(this.subjectRequestToast);
     }
+
     orderSubjectsByNameAscending(subjects) {
         return orderBy(subjects, [subject => subject.name.toLowerCase()], ['asc']);
     }
+
     orderSubjectsByNameDescending(subjects) {
         return orderBy(subjects, [subject => subject.name.toLowerCase()], ['desc']);
     }
+
     render() {
         return (
             <div className='pm-all-subjects'>
                 {
-                    this.props.ui.showDeleteConfirmModal &&
-                    <Modal vocab={this.props.vocab}
+                    this.props.ui.showDeleteConfirmModal
+                    && <Modal vocab={this.props.vocab}
                         title={this.props.vocab.MODAL.SUBJECT_DELETE_CONFIRM.TITLE}
                         bodyText={this.props.vocab.MODAL.SUBJECT_DELETE_CONFIRM[
-                            this.props.ui.showDeleteConfirmModal.confirmType ===
-                                CONFIRM_TYPE.SIMPLE ?
-                            'SIMPLE_CONFIRM' :
-                            'ASSOCIATED_PROJECT_CONFIRM'
+                            this.props.ui.showDeleteConfirmModal.confirmType
+                                === CONFIRM_TYPE.SIMPLE
+                                ? 'SIMPLE_CONFIRM'
+                                : 'ASSOCIATED_PROJECT_CONFIRM'
                         ]}
-                        onCancel={() =>
-                            this.props.actions.pmAllSubjectsHideDeleteConfirmModal()}
+                        onCancel={() => this.props.actions.pmAllSubjectsHideDeleteConfirmModal()}
                         onSave={() => {
                             apiService.subjects.deleteSubject(
-                                this.props.ui.showDeleteConfirmModal.id)
-                            .then(() => this.props.actions.pmAllSubjectsGetSubjects())
-                            .catch(() => {
-                                toast(this.props.vocab.ERROR.SUBJECT_REQUEST,
-                                    { autoClose: false, type: 'error' });
-                            });
+                                this.props.ui.showDeleteConfirmModal.id,
+                            )
+                                .then(() => this.props.actions.pmAllSubjectsGetSubjects())
+                                .catch(() => {
+                                    toast(this.props.vocab.ERROR.SUBJECT_REQUEST,
+                                        { autoClose: false, type: 'error' });
+                                });
                             this.props.actions.pmAllSubjectsHideDeleteConfirmModal();
                         }}
                         saveLabel={this.props.vocab.COMMON.DELETE}/>
@@ -89,8 +96,7 @@ class PMAllSubjects extends Component {
                 <div className='pm-all-subjects__search-wrapper'>
                     <FilterInput className='pm-all-subjects__search'
                         placeholder={this.props.vocab.PROJECT.SEARCH_FOR_SUBJECTS}
-                        onChange={evt =>
-                            this.props.actions.pmAllSubjectsSetQuery(evt.target.value)} />
+                        onChange={evt => this.props.actions.pmAllSubjectsSetQuery(evt.target.value)} />
                 </div>
                 <SubjectList
                     isOrderedByNameAscending={this.props.formState.isOrderedByNameAscending}

--- a/src/views/PMAllSubjects/components/index.js
+++ b/src/views/PMAllSubjects/components/index.js
@@ -9,8 +9,9 @@ import PMAllSubjects from './PMAllSubjects';
 class PMAllSubjectsContainer extends Component {
     componentWillMount() {
         this.props.actions.checkProtection(this.props.profile)
-          .then(this.props.actions.pmAllSubjectsGetSubjects());
+            .then(this.props.actions.pmAllSubjectsGetSubjects());
     }
+
     render() {
         return (
             <PMAllSubjects {...this.props} />

--- a/src/views/PMAllSubjects/reducer.js
+++ b/src/views/PMAllSubjects/reducer.js
@@ -15,9 +15,11 @@ const initialState = {
 export default (state = initialState, action) => {
     switch (action.type) {
     case actionTypes.PM_ALL_SUBJECTS_SET_QUERY:
-        return update(state, { ui: {
-            query: { $set: action.query },
-        } });
+        return update(state, {
+            ui: {
+                query: { $set: action.query },
+            },
+        });
     case actionTypes.PM_ALL_SUBJECTS_GET_SUBJECTS_SUCCESS:
         return update(state, {
             subjects: { $set: action.subjects },
@@ -35,13 +37,17 @@ export default (state = initialState, action) => {
             },
         });
     case actionTypes.PM_ALL_SUBJECTS_SHOW_DELETE_CONFIRM_MODAL:
-        return update(state, { ui: {
-            showDeleteConfirmModal: { $set: { id: action.id, confirmType: action.confirmType } },
-        } });
+        return update(state, {
+            ui: {
+                showDeleteConfirmModal: { $set: { id: action.id, confirmType: action.confirmType } },
+            },
+        });
     case actionTypes.PM_ALL_SUBJECTS_HIDE_DELETE_CONFIRM_MODAL:
-        return update(state, { ui: {
-            showDeleteConfirmModal: { $set: null },
-        } });
+        return update(state, {
+            ui: {
+                showDeleteConfirmModal: { $set: null },
+            },
+        });
     default:
         return state;
     }

--- a/src/views/PMAllUsers/components/PMAllUsers.js
+++ b/src/views/PMAllUsers/components/PMAllUsers.js
@@ -4,7 +4,7 @@ import { toast } from 'react-toastify';
 import Modal from '../../../common/components/Modal';
 import { renderName, DATA_STATE, getDataState } from '../../../utils/User';
 import PMUserList from '../../../common/components/PMUserList';
-import { UserProfileContainer } from '../../../views/UserProfile';
+import { UserProfileContainer } from '../../UserProfile';
 import InviteUserForm from '../../../common/components/InviteUserForm';
 import Search from '../../../common/components/Search';
 
@@ -16,25 +16,30 @@ class PMAllUsers extends Component {
         this.handleDeleteClick = this.handleDeleteClick.bind(this);
         this.handleDeleteModalSave = this.handleDeleteModalSave.bind(this);
     }
+
     handleDeleteClick(userId) {
         getDataState(userId)
-        .then(dataState => this.props.actions.pmAllUsersShowDeleteConfirmModal(userId, dataState))
-        .catch(() => toast(this.props.vocab.ERROR.USER_REQUEST, {
-            autoClose: false, type: 'error',
-        }));
+            .then(dataState => this.props.actions.pmAllUsersShowDeleteConfirmModal(userId, dataState))
+            .catch(() => toast(this.props.vocab.ERROR.USER_REQUEST, {
+                autoClose: false, type: 'error',
+            }));
     }
+
     handleDeleteModalSave(userId) {
         this.props.actions.deleteUser(userId, this.props.vocab.ERROR);
         this.props.actions.pmAllUsersHideDeleteConfirmModal();
     }
+
     handleSearchSelect(selection) {
         this.props.actions.pmAllUsersSetListQuery('');
         this.props.actions.pmAllUsersShowProfile(selection.value.id);
     }
+
     filterUser(user) {
         return renderName(user).toLowerCase()
             .includes((this.props.ui.listQuery).toLowerCase());
     }
+
     render() {
         const deleteModal = this.props.ui.showDeleteConfirmModal;
         return (
@@ -51,42 +56,43 @@ class PMAllUsers extends Component {
                             );
                         }}/>
                 </div>
-                 <div className='pm-all-users__search-container'>
-                     <Search
-                         placeholder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
-                         value={this.props.ui.listQuery}
-                         list={this.props.users.filter(this.filterUser)
-                             .map(user => ({ label: renderName(user),
-                                 value: user }))}
-                         onChange={evt =>
-                             this.props.actions.pmAllUsersSetListQuery(evt.target.value)}
-                         onSelect={this.handleSearchSelect}/>
-                 </div>
+                <div className='pm-all-users__search-container'>
+                    <Search
+                        placeholder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
+                        value={this.props.ui.listQuery}
+                        list={this.props.users.filter(this.filterUser)
+                            .map(user => ({
+                                label: renderName(user),
+                                value: user,
+                            }))}
+                        onChange={evt => this.props.actions.pmAllUsersSetListQuery(evt.target.value)}
+                        onSelect={this.handleSearchSelect}/>
+                </div>
                 <PMUserList {...this.props}
                     onUserNameClick={this.props.actions.pmAllUsersShowProfile}
                     onUserDeleteClick={this.handleDeleteClick}
-                    onUserMailClick={id =>
-                        this.props.actions.sendMessage(
-                            this.props.users.find(user => user.id === id))}/>
+                    onUserMailClick={id => this.props.actions.sendMessage(
+                        this.props.users.find(user => user.id === id),
+                    )}/>
                 {
-                    this.props.ui.showProfile !== false &&
-                    <UserProfileContainer userId={this.props.ui.showProfile}
+                    this.props.ui.showProfile !== false
+                    && <UserProfileContainer userId={this.props.ui.showProfile}
                         onCancel={() => this.props.actions.pmAllUsersShowProfile(false)}
                         onSave={() => this.props.actions.pmAllUsersShowProfile(false)}/>
                 }
                 {
-                    deleteModal &&
-                    <Modal title={this.props.vocab.MODAL.USER_DELETE_CONFIRM.TITLE}
+                    deleteModal
+                    && <Modal title={this.props.vocab.MODAL.USER_DELETE_CONFIRM.TITLE}
                         bodyText={
                             (
-                                deleteModal.promptType === DATA_STATE.HAS_DATA &&
-                                this.props.vocab.MODAL.USER_DELETE_CONFIRM.DELETE_WITH_DATA
-                            ) ||
-                            (
-                                deleteModal.promptType === DATA_STATE.HAS_TASKS &&
-                                this.props.vocab.MODAL.USER_DELETE_CONFIRM.DELETE_WITH_TASKS
-                            ) ||
-                            this.props.vocab.MODAL.USER_DELETE_CONFIRM.DELETE_WITH_NOTHING
+                                deleteModal.promptType === DATA_STATE.HAS_DATA
+                                && this.props.vocab.MODAL.USER_DELETE_CONFIRM.DELETE_WITH_DATA
+                            )
+                            || (
+                                deleteModal.promptType === DATA_STATE.HAS_TASKS
+                                && this.props.vocab.MODAL.USER_DELETE_CONFIRM.DELETE_WITH_TASKS
+                            )
+                            || this.props.vocab.MODAL.USER_DELETE_CONFIRM.DELETE_WITH_NOTHING
                         }
                         onCancel={() => this.props.actions.pmAllUsersHideDeleteConfirmModal()}
                         onSave={() => this.handleDeleteModalSave(deleteModal.id)}

--- a/src/views/PMAllUsers/components/index.js
+++ b/src/views/PMAllUsers/components/index.js
@@ -30,13 +30,14 @@ const mapStateToProps = store => ({
 
 const mapDispatchToProps = dispatch => ({
     actions: bindActionCreators(Object.assign({}, actions, userActions, { checkProtection },
-        { sendMessage: user => dispatch(push(
-            {
-                pathname: '/messages/new',
-                state: { message: { to: [user.email] } },
-            },
-        )) },
-    ), dispatch),
+        {
+            sendMessage: user => dispatch(push(
+                {
+                    pathname: '/messages/new',
+                    state: { message: { to: [user.email] } },
+                },
+            )),
+        }), dispatch),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(PMAllUsersContainer);

--- a/src/views/PMAllUsers/reducer.js
+++ b/src/views/PMAllUsers/reducer.js
@@ -13,24 +13,34 @@ export const initialState = {
 export default (state = initialState, action) => {
     switch (action.type) {
     case actionTypes.PM_ALL_USERS_SHOW_PROFILE:
-        return update(state, { ui: {
-            showProfile: { $set: action.userId },
-        } });
+        return update(state, {
+            ui: {
+                showProfile: { $set: action.userId },
+            },
+        });
     case actionTypes.PM_ALL_USERS_SET_LIST_QUERY:
-        return update(state, { ui: {
-            listQuery: { $set: action.query },
-        } });
+        return update(state, {
+            ui: {
+                listQuery: { $set: action.query },
+            },
+        });
     case actionTypes.PM_ALL_USERS_SHOW_DELETE_CONFIRM_MODAL:
-        return update(state, { ui: {
-            showDeleteConfirmModal: { $set: {
-                id: action.id,
-                promptType: action.promptType,
-            } },
-        } });
+        return update(state, {
+            ui: {
+                showDeleteConfirmModal: {
+                    $set: {
+                        id: action.id,
+                        promptType: action.promptType,
+                    },
+                },
+            },
+        });
     case actionTypes.PM_ALL_USERS_HIDE_DELETE_CONFIRM_MODAL:
-        return update(state, { ui: {
-            showDeleteConfirmModal: { $set: null },
-        } });
+        return update(state, {
+            ui: {
+                showDeleteConfirmModal: { $set: null },
+            },
+        });
     default:
         return state;
     }

--- a/src/views/PMDashboard/actions.js
+++ b/src/views/PMDashboard/actions.js
@@ -22,12 +22,12 @@ export function pmDashGetMessages() {
             limit: 4,
             received: true,
         })
-        .then((response) => {
-            dispatch(_getMessagesSuccess(response));
-        })
-        .catch((error) => {
-            dispatch(_getMessagesFailure(error));
-        });
+            .then((response) => {
+                dispatch(_getMessagesSuccess(response));
+            })
+            .catch((error) => {
+                dispatch(_getMessagesFailure(error));
+            });
     };
 }
 

--- a/src/views/PMDashboard/components/ProjectListEntry.js
+++ b/src/views/PMDashboard/components/ProjectListEntry.js
@@ -9,27 +9,26 @@ class ProjectListEntry extends Component {
     render() {
         return (
             <div className='project-list-entry'
-                onClick={() =>
-                    this.props.router.push(`/project/${this.props.project.id}`)}>
+                onClick={() => this.props.router.push(`/project/${this.props.project.id}`)}>
                 <div className='project-list-entry__name'>
                     {this.props.project.name}
                 </div>
                 <div className={`project-list-entry__status${
-                    this.props.project.status ?
-                        ' project-list-entry__status--active' : ''}`}>
-                    { this.props.project.status ?
-                        this.props.vocab.PROJECT.STATUS_ACTIVE :
-                        this.props.vocab.PROJECT.STATUS_INACTIVE}
+                    this.props.project.status
+                        ? ' project-list-entry__status--active' : ''}`}>
+                    { this.props.project.status
+                        ? this.props.vocab.PROJECT.STATUS_ACTIVE
+                        : this.props.vocab.PROJECT.STATUS_INACTIVE}
                 </div>
                 <div className='project-list-entry__name'>
                     {this.props.survey.name}
                 </div>
                 <div className={`project-list-entry__status${
-                    this.props.survey.status ?
-                        ' project-list-entry__status--active' : ''}`}>
-                    {this.props.survey.status === 'published' ?
-                        this.props.vocab.SURVEY.STATUS_PUBLISHED :
-                        this.props.vocab.SURVEY.STATUS_DRAFT}
+                    this.props.survey.status
+                        ? ' project-list-entry__status--active' : ''}`}>
+                    {this.props.survey.status === 'published'
+                        ? this.props.vocab.SURVEY.STATUS_PUBLISHED
+                        : this.props.vocab.SURVEY.STATUS_DRAFT}
                 </div>
                 <div className='project-list-entry__flags'>
                     <FlagCount value={this.props.flags} />

--- a/src/views/PMDashboard/components/ProjectListHeader.js
+++ b/src/views/PMDashboard/components/ProjectListHeader.js
@@ -1,21 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ProjectListHeader = ({ vocab }) =>
-    <div className='project-list-header'>
-        <div className='project-list-header__title project-list-header__title--project'>
-            {vocab.PROJECT.PROJECT}
-        </div>
-        <div className='project-list-header__title project-list-header__title--survey'>
-            {vocab.PROJECT.SURVEY}
-        </div>
-        <div className='project-list-header__title project-list-header__title--flags'>
-            {vocab.PROJECT.FLAGS}
-        </div>
-        <div className='project-list-header__title project-list-header__title--last-updated'>
-            {vocab.PROJECT.LAST_UPDATED}
-        </div>
-    </div>;
+const ProjectListHeader = ({ vocab }) => <div className='project-list-header'>
+    <div className='project-list-header__title project-list-header__title--project'>
+        {vocab.PROJECT.PROJECT}
+    </div>
+    <div className='project-list-header__title project-list-header__title--survey'>
+        {vocab.PROJECT.SURVEY}
+    </div>
+    <div className='project-list-header__title project-list-header__title--flags'>
+        {vocab.PROJECT.FLAGS}
+    </div>
+    <div className='project-list-header__title project-list-header__title--last-updated'>
+        {vocab.PROJECT.LAST_UPDATED}
+    </div>
+</div>;
 
 ProjectListHeader.propTypes = {
     vocab: PropTypes.object.isRequired,

--- a/src/views/PMDashboard/components/index.js
+++ b/src/views/PMDashboard/components/index.js
@@ -70,15 +70,15 @@ class PMDashboard extends Component {
                     filter={this.props.ui.filter} />
                 <div className='pm-dashboard__table'>
                     <ProjectListHeader vocab={this.props.vocab} />
-                    { this.props.ui.noData ?
-                        (<div className='pm-dashboard__no-data'>
+                    { this.props.ui.noData
+                        ? (<div className='pm-dashboard__no-data'>
                             {this.props.vocab.PROJECT.NO_PROJECTS}
-                        </div>) :
-                    this.props.rows.filter(this.filterRow.bind(this))
-                        .filter(this.searchRow.bind(this))
-                        .map(row => <ProjectListEntry key={`proj${row.project.id}`} {...row}
-                            vocab={this.props.vocab}
-                        />)
+                        </div>)
+                        : this.props.rows.filter(this.filterRow.bind(this))
+                            .filter(this.searchRow.bind(this))
+                            .map(row => <ProjectListEntry key={`proj${row.project.id}`} {...row}
+                                vocab={this.props.vocab}
+                            />)
                     }
                 </div>
             </div>
@@ -97,8 +97,7 @@ const mapStateToProps = store => ({
     profile: store.user.profile,
     rows: store.projects.data.map(project => ({
         project: _.pick(project, ['name', 'status', 'id', 'lastUpdated']),
-        survey: _.pick(store.surveys.data.find(survey =>
-            survey.id === project.surveyId), ['name', 'status', 'id']),
+        survey: _.pick(store.surveys.data.find(survey => survey.id === project.surveyId), ['name', 'status', 'id']),
         flags: project.flags || 0,
     })),
     glance: {

--- a/src/views/PrimaryNav/index.js
+++ b/src/views/PrimaryNav/index.js
@@ -61,12 +61,12 @@ class PrimaryNavContainer extends Component {
     }
 
     render() {
-        const isProjectManager = ((this.props.user.profile.roleID === 2) ||
-            (this.props.user.profile.roleID === 1));
+        const isProjectManager = ((this.props.user.profile.roleID === 2)
+            || (this.props.user.profile.roleID === 1));
         return (
             <nav className='primary-nav'>
-                {this.props.ui.showCreateProject &&
-                <CreateNewProject vocab={this.props.vocab}
+                {this.props.ui.showCreateProject
+                && <CreateNewProject vocab={this.props.vocab}
                     showCreateProject={this.props.actions.showCreateProject}
                     goToNewProject={this.props.goToNewProject}/>}
 
@@ -80,23 +80,23 @@ class PrimaryNavContainer extends Component {
                         activeClassName='primary-nav__item-nav--active'>
                         {this.props.vocab.COMMON.MY_TASKS}
                     </Link>
-                    {isProjectManager &&
-                    <Link className='primary-nav__item-nav' to='/project'
+                    {isProjectManager
+                    && <Link className='primary-nav__item-nav' to='/project'
                         activeClassName='primary-nav__item-nav--active'>
                         {this.props.vocab.PROJECT.PROJECTS}
                     </Link>}
-                    {isProjectManager &&
-                    <Link className='primary-nav__item-nav' to='/users'
+                    {isProjectManager
+                    && <Link className='primary-nav__item-nav' to='/users'
                         activeClassName='primary-nav__item-nav--active'>
                         {this.props.vocab.COMMON.ALL_USERS}
                     </Link>}
-                    {isProjectManager &&
-                    <Link className='primary-nav__item-nav' to='/subjects'
+                    {isProjectManager
+                    && <Link className='primary-nav__item-nav' to='/subjects'
                         activeClassName='primary-nav__item-nav--active'>
                         {this.props.vocab.COMMON.ALL_SUBJECTS}
                     </Link>}
-                    {isProjectManager &&
-                        <button className='primary-nav__item-nav primary-nav__button'
+                    {isProjectManager
+                        && <button className='primary-nav__item-nav primary-nav__button'
                             onClick={this.handleShowCreateProject}>
                             <span>{this.props.vocab.COMMON.CREATE}</span>
                         </button>}

--- a/src/views/Profile/components/ProfileCheckBox.js
+++ b/src/views/Profile/components/ProfileCheckBox.js
@@ -5,8 +5,8 @@ class ProfileCheckBox extends Component {
     render() {
         return (
             <CheckBox
-                checked={typeof this.props.input.value === 'boolean' ?
-                    this.props.input.value : false }
+                checked={typeof this.props.input.value === 'boolean'
+                    ? this.props.input.value : false }
                 value={this.props.input.value}
                 onChange={this.props.input.onChange}
                 disabled={true}

--- a/src/views/Profile/components/ProfileForm.js
+++ b/src/views/Profile/components/ProfileForm.js
@@ -9,8 +9,7 @@ class ProfileForm extends Component {
     render() {
         const isProjectManager = ((this.props.profile.roleID === 1)
             || (this.props.profile.roleID === 2));
-        const notifyOptions = this.props.vocab.PROFILE.FORM.LEVELS.map((level, index) =>
-            ({ value: index, label: level }));
+        const notifyOptions = this.props.vocab.PROFILE.FORM.LEVELS.map((level, index) => ({ value: index, label: level }));
         return (
             <form className='profile-form' onSubmit={this.props.handleSubmit}>
                 <div className='profile-form__header'>
@@ -19,8 +18,8 @@ class ProfileForm extends Component {
                     </div>
                     <button className='profile-form__button'
                         onClick={this.props.handleSubmit}>
-                            <span>{this.props.vocab.PROFILE.FORM.SAVE_SETTINGS}</span>
-                        </button>
+                        <span>{this.props.vocab.PROFILE.FORM.SAVE_SETTINGS}</span>
+                    </button>
                 </div>
                 <div className='profile-form__user-info'>
                     <div className='profile-form__section-header'>
@@ -29,7 +28,7 @@ class ProfileForm extends Component {
                     <div className='profile-form__name-row'>
                         <div className='profile-form__field'>
                             <label className='profile-form__field-label'>
-                            {this.props.vocab.COMMON.FIRST_NAME} </label>
+                                {this.props.vocab.COMMON.FIRST_NAME} </label>
                             <Field name='firstName'
                                 value={this.props.profile.firstName}
                                 component='input'
@@ -38,7 +37,7 @@ class ProfileForm extends Component {
                         </div>
                         <div className='profile-form__field-spaced'>
                             <label className='profile-form__field-label'>
-                            {this.props.vocab.COMMON.LAST_NAME} </label>
+                                {this.props.vocab.COMMON.LAST_NAME} </label>
                             <Field name='lastName'
                                 value={this.props.profile.lastName}
                                 component='input'
@@ -48,7 +47,7 @@ class ProfileForm extends Component {
                     </div>
                     <div className='profile-form__field'>
                         <label className='profile-form__field-label'>
-                        {this.props.vocab.COMMON.EMAIL} </label>
+                            {this.props.vocab.COMMON.EMAIL} </label>
                         <Field name='email'
                             value={this.props.profile.email}
                             component='input'
@@ -62,22 +61,22 @@ class ProfileForm extends Component {
                         {this.props.vocab.PROFILE.FORM.NOTIFICATION_AND_STATUS}
                     </div>
                     <label className='profile-form__field-label'>
-                    {this.props.vocab.PROFILE.FORM.NOTIFY_LEVEL} </label>
+                        {this.props.vocab.PROFILE.FORM.NOTIFY_LEVEL} </label>
                     <Field name='notifyLevel'
                         value={this.props.profile.notifyLevel}
                         component={ProfileSelect}
                         options={notifyOptions}
                         type='select' />
-                    {isProjectManager &&
-                    <label className='profile-form__field-label'>
+                    {isProjectManager
+                    && <label className='profile-form__field-label'>
                         {this.props.vocab.PROFILE.FORM.ACTIVE_STATUS} </label>}
-                    {isProjectManager &&
-                    <Field name='isActive'
-                           value={this.props.profile.isActive}
-                           component={ProfileCheckBox}
-                           type='checkbox'/>}
+                    {isProjectManager
+                    && <Field name='isActive'
+                        value={this.props.profile.isActive}
+                        component={ProfileCheckBox}
+                        type='checkbox'/>}
                     <label className='profile-form__field-label'>
-                    {this.props.vocab.PROFILE.FORM.NOTES} </label>
+                        {this.props.vocab.PROFILE.FORM.NOTES} </label>
                     <Field name='bio'
                         value={this.props.profile.isActive}
                         component='textarea'

--- a/src/views/Profile/components/ProfileSelect.js
+++ b/src/views/Profile/components/ProfileSelect.js
@@ -7,9 +7,9 @@ class ProfileSelect extends Component {
         if (this.props.input.value === '') {
             value = this.props.options[this.props.options.length - 1];
         } else {
-            value = typeof this.props.input.value === 'number' ?
-                this.props.options[this.props.input.value] :
-                this.props.input.value;
+            value = typeof this.props.input.value === 'number'
+                ? this.props.options[this.props.input.value]
+                : this.props.input.value;
         }
 
         return (

--- a/src/views/Profile/components/ProfileSelect.js
+++ b/src/views/Profile/components/ProfileSelect.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Select } from 'grommet';
+import Select from 'grommet/components/Select';
 
 class ProfileSelect extends Component {
     render() {

--- a/src/views/Profile/components/ResetPasswordPanel.js
+++ b/src/views/Profile/components/ResetPasswordPanel.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'grommet';
+import Button from 'grommet/components/Button';
 
 class ResetPasswordPanel extends Component {
     render() {

--- a/src/views/Profile/components/index.js
+++ b/src/views/Profile/components/index.js
@@ -19,7 +19,8 @@ class ProfileContainer extends Component {
                     onSubmit={(values) => {
                         this.props.actions.updateProfile(
                             values,
-                            this.props.vocab.ERROR);
+                            this.props.vocab.ERROR,
+                        );
                     }} />
                 <ResetPasswordPanel {...this.props} />
             </div>

--- a/src/views/ProjectManagement/components/Export/index.js
+++ b/src/views/ProjectManagement/components/Export/index.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Field, reduxForm, formValueSelector, change } from 'redux-form';
+import {
+    Field, reduxForm, formValueSelector, change,
+} from 'redux-form';
 
 class Export extends Component {
     constructor(props) {
@@ -10,22 +12,25 @@ class Export extends Component {
         this.addAllSubjects = this.addAllSubjects.bind(this);
         this.handleSubjectsChange = this.handleSubjectsChange.bind(this);
     }
+
     addAllSubjects() {
         this.props.setValue('subjectsList', [...this.props.subjects]);
     }
+
     handleSubjectsChange(event, newValue) {
         if (newValue) {
             this.addAllSubjects();
         }
     }
+
     render() {
         const quickType = this.props.selectedType === 'quick';
         return (
             <form className='export' onSubmit={this.props.handleSubmit}>
-            <div className='export__wrapper'>
-                <div className='export__instructions'>
-                    {this.props.vocab.EXPORT.INSTRUCTIONS}
-                </div>
+                <div className='export__wrapper'>
+                    <div className='export__instructions'>
+                        {this.props.vocab.EXPORT.INSTRUCTIONS}
+                    </div>
                 </div>
                 <div className='export__interactions'>
                     <div className='export__configuration'>

--- a/src/views/ProjectManagement/components/Modals/ProjectStatus/InactiveConfirm.js
+++ b/src/views/ProjectManagement/components/Modals/ProjectStatus/InactiveConfirm.js
@@ -10,7 +10,7 @@ class InactiveConfirm extends Component {
                 saveLabel={this.props.vocab.COMMON.CONFIRM}
                 onSave={ () => {
                     const newProject = Object.assign({}, this.props.project,
-                            { status: 0 });
+                        { status: 0 });
                     this.props.actions.putProject(newProject, this.props.vocab.ERROR);
                     this.props.actions.showInactiveConfirmModal(false);
                     this.props.actions.updateStatusChange(false);

--- a/src/views/ProjectManagement/components/Modals/ProjectStatus/ProjectStatusForm.js
+++ b/src/views/ProjectManagement/components/Modals/ProjectStatus/ProjectStatusForm.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import { toast } from 'react-toastify';
-import { form, Field, reduxForm, reset } from 'redux-form';
+import {
+    form, Field, reduxForm, reset,
+} from 'redux-form';
 import ConfirmationCheckbox from '../ConfirmationCheckbox';
 
 class ProjectStatusForm extends Component {
@@ -19,9 +21,9 @@ class ProjectStatusForm extends Component {
                     <label htmlFor='project-status-check' className='toggle'></label>
                     <div className='project-status-form__field'>
                         <div className='project-status-form__text'>
-                            {this.props.active ?
-                              vocab.PROJECT.STATUS_ACTIVE :
-                              vocab.PROJECT.STATUS_INACTIVE}
+                            {this.props.active
+                                ? vocab.PROJECT.STATUS_ACTIVE
+                                : vocab.PROJECT.STATUS_INACTIVE}
                         </div>
                         <div className='project-status-form__label'>
                             {projectVocab.VALUE_LABEL}
@@ -69,18 +71,18 @@ export default reduxForm({
         // Check the checkboxes to ensure they are all true.
         if (values.active && values.draftConfirm && values.accessConfirm && values.usersConfirm) {
             const newProject = Object.assign({}, ownProps.project,
-                    { status: 1 });
+                { status: 1 });
             ownProps.putProject(newProject, ownProps.vocab.ERROR)
-            .catch((error) => {
-                toast(
+                .catch((error) => {
+                    toast(
                     // greyscale provides readable error messages in 4xx
-                    error.body.e >= 400 && error.body.e < 500 ?
-                    error.body.message :
-                    // fallback to generic error message
-                    ownProps.vocab.ERROR.PROJECT_ACTIVATE,
-                    { type: 'error', autoClose: false },
-                );
-            });
+                        error.body.e >= 400 && error.body.e < 500
+                            ? error.body.message
+                        // fallback to generic error message
+                            : ownProps.vocab.ERROR.PROJECT_ACTIVATE,
+                        { type: 'error', autoClose: false },
+                    );
+                });
             ownProps.updateStatusChange(false);
         } else if (values.draftConfirm && values.accessConfirm && values.usersConfirm) {
             ownProps.showInactiveConfirmModal(true);

--- a/src/views/ProjectManagement/components/Modals/ProjectStatus/index.js
+++ b/src/views/ProjectManagement/components/Modals/ProjectStatus/index.js
@@ -8,26 +8,26 @@ import ProjectStatusForm from './ProjectStatusForm';
 class ProjectStatus extends Component {
     render() {
         return (
-                <Modal
-                    class='project-status-change-layer'
-                    title={this.props.vocab.MODAL.STATUS_CHANGE_MODAL.PROJECT_TAB.TITLE}
-                    onSave={this.props.onClickToSubmit}
-                    onCancel={() => this.props.actions.updateStatusChange(false)}>
-                        <ProjectStatusForm
-                            initialValues={{
-                                active: this.props.project.status,
-                                draftConfirm: false,
-                                accessConfirm: false,
-                                usersConfirm: false,
-                            }}
-                            project={this.props.project}
-                            vocab={this.props.vocab}
-                            active={this.props.active}
-                            putProject={this.props.actions.putProject}
-                            updateStatusChange={this.props.actions.updateStatusChange}
-                            showInactiveConfirmModal={this.props.actions.showInactiveConfirmModal}
-                            />
-                </Modal>
+            <Modal
+                class='project-status-change-layer'
+                title={this.props.vocab.MODAL.STATUS_CHANGE_MODAL.PROJECT_TAB.TITLE}
+                onSave={this.props.onClickToSubmit}
+                onCancel={() => this.props.actions.updateStatusChange(false)}>
+                <ProjectStatusForm
+                    initialValues={{
+                        active: this.props.project.status,
+                        draftConfirm: false,
+                        accessConfirm: false,
+                        usersConfirm: false,
+                    }}
+                    project={this.props.project}
+                    vocab={this.props.vocab}
+                    active={this.props.active}
+                    putProject={this.props.actions.putProject}
+                    updateStatusChange={this.props.actions.updateStatusChange}
+                    showInactiveConfirmModal={this.props.actions.showInactiveConfirmModal}
+                />
+            </Modal>
         );
     }
 }

--- a/src/views/ProjectManagement/components/Modals/Stage/StageForm.js
+++ b/src/views/ProjectManagement/components/Modals/Stage/StageForm.js
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { Field, reduxForm, form, formValueSelector } from 'redux-form';
+import {
+    Field, reduxForm, form, formValueSelector,
+} from 'redux-form';
 
 import StageDateTime from './StageDateTime';
 import StageSelect from './StageSelect';
@@ -14,8 +16,8 @@ class StageForm extends Component {
                 <div>
                     <div className='stage-form__title'>
                         <label className='stage-form__title-label'>
-                        {this.props.vocab.PROJECT.STAGE_TITLE}
-                         </label>
+                            {this.props.vocab.PROJECT.STAGE_TITLE}
+                        </label>
                         <div>
                             <Field
                                 name='title'
@@ -27,7 +29,7 @@ class StageForm extends Component {
                     </div>
                     <div className='stage-form__group'>
                         <label className='stage-form__group-name'>
-                        {this.props.vocab.PROJECT.ASSIGN_USER_GROUPS}
+                            {this.props.vocab.PROJECT.ASSIGN_USER_GROUPS}
                         </label>
                         <div>
                             <Field
@@ -41,38 +43,36 @@ class StageForm extends Component {
                     </div>
 
                     <div className='stage-form__activities'>
-                           <label className='stage-form__activities-label'>
-                           {this.props.vocab.PROJECT.PERMISSIONS}
-                           </label>
-                       <div className='stage-form__radio-control'>
-                           {this.props.vocab.PROJECT.ACTIVITY_OPTIONS.map((permission, index) =>
-                               <label className='stage-form__radio-button' key={index}>
-                                   <Field
-                                       name='permissions'
-                                       component='input'
-                                       type='radio'
-                                       value={`${index}`} />
-                                   <span
-                                       className='stage-form__permission-label-text'>
-                                       {permission}
-                                   </span>
-                               </label>,
-                           )}
-                       </div>
+                        <label className='stage-form__activities-label'>
+                            {this.props.vocab.PROJECT.PERMISSIONS}
+                        </label>
+                        <div className='stage-form__radio-control'>
+                            {this.props.vocab.PROJECT.ACTIVITY_OPTIONS.map((permission, index) => <label className='stage-form__radio-button' key={index}>
+                                <Field
+                                    name='permissions'
+                                    component='input'
+                                    type='radio'
+                                    value={`${index}`} />
+                                <span
+                                    className='stage-form__permission-label-text'>
+                                    {permission}
+                                </span>
+                            </label>)}
+                        </div>
                     </div>
                     <div className='stage-form__text-description'>
                         {this.props.vocab.PROJECT.ACTIVITY_DESC[this.props.permissions]}
                     </div>
                     <hr className='stage-form__divider'/>
                     <div className='stage-form__date'>
-                            <label className='stage-form__date-label'>
+                        <label className='stage-form__date-label'>
                             {this.props.vocab.PROJECT.DATE_RANGE}
-                            </label>
+                        </label>
                     </div>
                     <div className='stage-form__select'>
                         <div className='stage-form__select-start'>
                             <label className='stage-form__select-start-label'>
-                            {this.props.vocab.PROJECT.START_DATE}</label>
+                                {this.props.vocab.PROJECT.START_DATE}</label>
                             <div className='stage-form__date-input-div'>
                                 <Field
                                     id='StartDate'

--- a/src/views/ProjectManagement/components/Modals/Stage/index.js
+++ b/src/views/ProjectManagement/components/Modals/Stage/index.js
@@ -8,14 +8,11 @@ import StageForm from './StageForm';
 
 class StageModal extends Component {
     render() {
-        const groups = this.props.userGroups.map((group, key) =>
-            ({ value: group.id, label: group.title, key }),
-        );
+        const groups = this.props.userGroups.map((group, key) => ({ value: group.id, label: group.title, key }));
 
         let initialValues;
         if (this.props.stageId && this.props.project) {
-            initialValues = Object.assign({}, this.props.project.stages.find(stage =>
-                stage.id === this.props.stageId));
+            initialValues = Object.assign({}, this.props.project.stages.find(stage => stage.id === this.props.stageId));
             if (initialValues.blindReview) {
                 initialValues.permissions = '1';
             } else if (initialValues.discussionParticipation) {
@@ -42,19 +39,18 @@ class StageModal extends Component {
                 class='add-stage-layer'
                 onCancel={this.props.onCancel}
                 onSave={this.props.onClickToSubmit}
-                buttons={(this.props.stageId !== undefined && this.props.stageId !== null) ?
-                [{
-                    key: 'delete-button',
-                    label: this.props.vocab.PROJECT.DELETE_STAGE,
-                    onClick: this.props.onDeleteClick,
-                }] : null}>
+                buttons={(this.props.stageId !== undefined && this.props.stageId !== null)
+                    ? [{
+                        key: 'delete-button',
+                        label: this.props.vocab.PROJECT.DELETE_STAGE,
+                        onClick: this.props.onDeleteClick,
+                    }] : null}>
                 <StageForm
                     vocab={this.props.vocab}
                     groups={groups}
                     initialValues={initialValues}
-                    onSubmit={values =>
-                            this.props.onAddStage(stageMapping(values), this.props.project.id)
-                        } />
+                    onSubmit={values => this.props.onAddStage(stageMapping(values), this.props.project.id)
+                    } />
             </Modal>
         );
     }

--- a/src/views/ProjectManagement/components/Modals/Subject/index.js
+++ b/src/views/ProjectManagement/components/Modals/Subject/index.js
@@ -28,8 +28,7 @@ SubjectModal.propTypes = {
 };
 
 const subjectMapping = (values) => {
-    return values.subjects.split(/\s*,\s*/).filter(subject =>
-        subject).map((subject) => { return { name: subject }; });
+    return values.subjects.split(/\s*,\s*/).filter(subject => subject).map((subject) => { return { name: subject }; });
 };
 
 export default SubjectModal;

--- a/src/views/ProjectManagement/components/Modals/SurveyStatus/SurveyStatusForm.js
+++ b/src/views/ProjectManagement/components/Modals/SurveyStatus/SurveyStatusForm.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
-import { form, Field, reduxForm, reset } from 'redux-form';
+import {
+    form, Field, reduxForm, reset,
+} from 'redux-form';
 import ConfirmationCheckbox from '../ConfirmationCheckbox';
 
 class SurveyStatusForm extends Component {
@@ -66,9 +68,9 @@ export default reduxForm({
         // Check the checkboxes to ensure they are all true.
         if (values.editConfirm && values.accessConfirm && values.usersConfirm) {
             ownProps.patchSurvey(Object.assign({}, ownProps.survey,
-                    { status: values.published ? 'published' : 'draft' }),
-                ownProps.vocab.SURVEY.SUCCESS,
-                ownProps.vocab.ERROR);
+                { status: values.published ? 'published' : 'draft' }),
+            ownProps.vocab.SURVEY.SUCCESS,
+            ownProps.vocab.ERROR);
             ownProps.updateStatusChange(false);
         }
     },

--- a/src/views/ProjectManagement/components/Modals/SurveyStatus/index.js
+++ b/src/views/ProjectManagement/components/Modals/SurveyStatus/index.js
@@ -8,25 +8,25 @@ import SurveyStatusForm from './SurveyStatusForm';
 class SurveyStatus extends Component {
     render() {
         return (
-                <Modal
-                    class='project-status-change-layer'
-                    title={this.props.vocab.MODAL.STATUS_CHANGE_MODAL.SURVEY_TAB.TITLE}
-                    onSave={this.props.onClickToSubmit}
-                    onCancel={() => this.props.actions.updateStatusChange(false)}>
-                        <SurveyStatusForm
-                            initialValues={{
-                                published: this.props.survey.status === 'published',
-                                editConfirm: false,
-                                accessConfirm: false,
-                                usersConfirm: false,
-                            }}
-                            survey={this.props.survey}
-                            vocab={this.props.vocab}
-                            published={this.props.published}
-                            patchSurvey={this.props.actions.patchSurvey}
-                            updateStatusChange={this.props.actions.updateStatusChange}
-                            />
-                </Modal>
+            <Modal
+                class='project-status-change-layer'
+                title={this.props.vocab.MODAL.STATUS_CHANGE_MODAL.SURVEY_TAB.TITLE}
+                onSave={this.props.onClickToSubmit}
+                onCancel={() => this.props.actions.updateStatusChange(false)}>
+                <SurveyStatusForm
+                    initialValues={{
+                        published: this.props.survey.status === 'published',
+                        editConfirm: false,
+                        accessConfirm: false,
+                        usersConfirm: false,
+                    }}
+                    survey={this.props.survey}
+                    vocab={this.props.vocab}
+                    published={this.props.published}
+                    patchSurvey={this.props.actions.patchSurvey}
+                    updateStatusChange={this.props.actions.updateStatusChange}
+                />
+            </Modal>
         );
     }
 }

--- a/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsForm.js
+++ b/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsForm.js
@@ -10,46 +10,46 @@ import { renderName } from '../../../../../utils/User';
 class TaskOptionsForm extends Component {
     render() {
         return (
-                <form className='task-options-form'
-                    onSubmit={this.props.handleSubmit}>
-                    <Field
-                        name='choice'
-                        component={TaskOptionsRadio}
-                        type='radio'
-                        value='force'
-                        label={this.props.vocab.PROJECT.OPTIONS_MODAL.FORCE} />
-                    <div className='task-options-form__header-paragraph'>
-                        {this.props.vocab.PROJECT.OPTIONS_MODAL.FORCE_PARAGRAPH}
-                    </div>
-                    <Field
-                        name='choice'
-                        component={TaskOptionsRadio}
-                        type='radio'
-                        value='reassign'
-                        label={this.props.vocab.PROJECT.OPTIONS_MODAL.REASSIGN} />
-                    <Field
-                        name='reassignUser'
-                        component={TaskOptionsSelect}
-                        type='select'
-                        currentUser={this.props.currentUser}
-                        userOptions={this.props.userOptions}/>
-                    <hr className='task-options-form__divider'/>
-                    <Field
-                        name='notify'
-                        component={TaskOptionsCheckbox}
-                        type='checkbox'
-                        value='false'
-                        label={this.props.vocab.PROJECT.OPTIONS_MODAL.NOTIFY} />
-                    <div className='task-options__notify-user-warning'>
-                        { renderName(this.props.currentUser)
+            <form className='task-options-form'
+                onSubmit={this.props.handleSubmit}>
+                <Field
+                    name='choice'
+                    component={TaskOptionsRadio}
+                    type='radio'
+                    value='force'
+                    label={this.props.vocab.PROJECT.OPTIONS_MODAL.FORCE} />
+                <div className='task-options-form__header-paragraph'>
+                    {this.props.vocab.PROJECT.OPTIONS_MODAL.FORCE_PARAGRAPH}
+                </div>
+                <Field
+                    name='choice'
+                    component={TaskOptionsRadio}
+                    type='radio'
+                    value='reassign'
+                    label={this.props.vocab.PROJECT.OPTIONS_MODAL.REASSIGN} />
+                <Field
+                    name='reassignUser'
+                    component={TaskOptionsSelect}
+                    type='select'
+                    currentUser={this.props.currentUser}
+                    userOptions={this.props.userOptions}/>
+                <hr className='task-options-form__divider'/>
+                <Field
+                    name='notify'
+                    component={TaskOptionsCheckbox}
+                    type='checkbox'
+                    value='false'
+                    label={this.props.vocab.PROJECT.OPTIONS_MODAL.NOTIFY} />
+                <div className='task-options__notify-user-warning'>
+                    { renderName(this.props.currentUser)
                             + this.props.vocab.PROJECT.OPTIONS_MODAL._WILL_BE_NOTIFIED }
-                    </div>
-                    <Field
-                        name='message'
-                        className={'task-options-form__header-text-box' +
-                            ' task-options-form__notify-user-warning-text-box'}
-                        component='textarea' />
-                </form>
+                </div>
+                <Field
+                    name='message'
+                    className={'task-options-form__header-text-box'
+                            + ' task-options-form__notify-user-warning-text-box'}
+                    component='textarea' />
+            </form>
         );
     }
 }

--- a/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsSelect.js
+++ b/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsSelect.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Select } from 'grommet';
+import Select from 'grommet/components/Select';
 
 class TaskOptionsSelect extends Component {
     render() {

--- a/src/views/ProjectManagement/components/Modals/TaskOptions/index.js
+++ b/src/views/ProjectManagement/components/Modals/TaskOptions/index.js
@@ -12,16 +12,15 @@ import TaskOptionsForm from './TaskOptionsForm';
 
 class TaskOptionsModal extends Component {
     render() {
-        const currentUser = find(this.props.users, user =>
-            user.id === this.props.task.userIds[0]);
-        const userOptions = this.props.users.filter(user =>
-            intersection(user.usergroupId, this.props.userGroups).length > 0,
-        ).map((user) => {
-            return user === currentUser ?
-            { value: user,
-                label: renderName(user) +
-                    this.props.vocab.PROJECT.OPTIONS_MODAL._CURRENTLY_ASSIGNED } :
-                { value: user, label: renderName(user) };
+        const currentUser = find(this.props.users, user => user.id === this.props.task.userIds[0]);
+        const userOptions = this.props.users.filter(user => intersection(user.usergroupId, this.props.userGroups).length > 0).map((user) => {
+            return user === currentUser
+                ? {
+                    value: user,
+                    label: renderName(user)
+                    + this.props.vocab.PROJECT.OPTIONS_MODAL._CURRENTLY_ASSIGNED,
+                }
+                : { value: user, label: renderName(user) };
         });
         const initialValues = {
             choice: null,

--- a/src/views/ProjectManagement/components/SubNav/SubNavEntry.js
+++ b/src/views/ProjectManagement/components/SubNav/SubNavEntry.js
@@ -5,8 +5,8 @@ class SubNavEntry extends Component {
     render() {
         return (
             <div
-                className={`sub-nav-entry ${this.props.selected ?
-                    'sub-nav-entry--selected' : ''} `}
+                className={`sub-nav-entry ${this.props.selected
+                    ? 'sub-nav-entry--selected' : ''} `}
                 onClick={this.props.onClick}>
                 {this.props.label}
             </div>

--- a/src/views/ProjectManagement/components/SubNav/index.js
+++ b/src/views/ProjectManagement/components/SubNav/index.js
@@ -14,15 +14,14 @@ class SubNav extends Component {
 
         return (
             <div className='sub-nav'>
-                {subNavEntries.map((entry, i) =>
-                    <SubNavEntry
-                        {...entry}
-                        first={i === 0}
-                        selected={this.props.selected === entry.key}
-                        onClick={() => this.props.subnavigate(entry.key)}
-                        />)
-                    }
-                </div>
+                {subNavEntries.map((entry, i) => <SubNavEntry
+                    {...entry}
+                    first={i === 0}
+                    selected={this.props.selected === entry.key}
+                    onClick={() => this.props.subnavigate(entry.key)}
+                />)
+                }
+            </div>
         );
     }
 }

--- a/src/views/ProjectManagement/components/Subjects/index.js
+++ b/src/views/ProjectManagement/components/Subjects/index.js
@@ -36,47 +36,53 @@ class Subjects extends Component {
             this.subjectHasData(subject.id).then((hasData) => {
                 if (hasData) {
                     toast(this.props.vocab.ERROR.NO_DELETE_SUBJECT_WITH_DATA,
-                        { autoClose: false,
-                            type: 'error' });
+                        {
+                            autoClose: false,
+                            type: 'error',
+                        });
                 } else {
                     this.props.actions
-                            .showSubjectDeleteConfirmModalForId(subject.id);
+                        .showSubjectDeleteConfirmModalForId(subject.id);
                 }
             });
         }
     }
+
     subjectHasData(subjectId) {
-        const answerPromises =
-        this.props.tasks
-        .filter(task => task.uoaId === subjectId)
-        .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId));
+        const answerPromises = this.props.tasks
+            .filter(task => task.uoaId === subjectId)
+            .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId));
         return Promise.all(answerPromises)
-        .then(statuses => statuses.some(status => status.status !== 'new'));
+            .then(statuses => statuses.some(status => status.status !== 'new'));
     }
+
     orderSubjectsByNameAscending(subjects) {
         return orderBy(subjects, [subject => subject.name.toLowerCase()], ['asc']);
     }
+
     orderSubjectsByNameDescending(subjects) {
         return orderBy(subjects, [subject => subject.name.toLowerCase()], ['desc']);
     }
+
     render() {
         return (
             <div className='subjects'>
-                {this.state.showAddSubjectModal &&
-                    <SubjectModal
+                {this.state.showAddSubjectModal
+                    && <SubjectModal
                         onAddSubject={(subjects) => {
                             this.setState({ showAddSubjectModal: false });
                             this.props.actions.addSubject(
                                 this.props.project,
                                 subjects,
                                 false,
-                                this.props.vocab.ERROR);
+                                this.props.vocab.ERROR,
+                            );
                         }}
                         onCancel={this.closeAddSubjectModal}
                         vocab={this.props.vocab}/>}
                 {
-                    this.props.ui.showSubjectDeleteConfirmModalForId !== null &&
-                    <Modal vocab={this.props.vocab}
+                    this.props.ui.showSubjectDeleteConfirmModalForId !== null
+                    && <Modal vocab={this.props.vocab}
                         title={this.props.vocab.MODAL.SUBJECT_DELETE_CONFIRM.TITLE}
                         bodyText={this.props.vocab.MODAL.SUBJECT_DELETE_CONFIRM.SIMPLE_CONFIRM}
                         onCancel={() => this.props.actions.showSubjectDeleteConfirmModalForId(null)}
@@ -85,7 +91,8 @@ class Subjects extends Component {
                                 this.props.project,
                                 this.props.ui.showSubjectDeleteConfirmModalForId,
                                 false,
-                                this.props.vocab.ERROR);
+                                this.props.vocab.ERROR,
+                            );
                             this.props.actions.showSubjectDeleteConfirmModalForId(null);
                         }}
                         saveLabel={this.props.vocab.COMMON.DELETE} />

--- a/src/views/ProjectManagement/components/Users/PMUserGroupsTab.js
+++ b/src/views/ProjectManagement/components/Users/PMUserGroupsTab.js
@@ -18,12 +18,14 @@ class PMUserGroupsTab extends Component {
         this.handleDeleteClick = this.handleDeleteClick.bind(this);
         this.handleDeleteModalSave = this.handleDeleteModalSave.bind(this);
     }
+
     getDataState(userGroupId) {
         if (!this.props.project.stages.some(stage => stage.userGroups.includes(userGroupId))) {
             return NO_STAGES;
         }
         return STAGES;
     }
+
     handleDeleteClick(userGroupId) {
         const dataState = this.getDataState(userGroupId);
         if (dataState === NO_STAGES) {
@@ -35,29 +37,32 @@ class PMUserGroupsTab extends Component {
             this.props.actions.pmShowUserGroupDeleteConfirmModal(userGroupId, dataState);
         }
     }
+
     handleDeleteModalSave() {
         apiService.projects.deleteGroup(this.props.ui.showUserGroupDeleteConfirmModal.id)
-        .catch(() => toast(this.props.vocab.ERROR.GROUP_DELETE,
-            { autoClose: false, type: 'error' }))
-        .then(() => {
-            this.props.actions.getProjectById(this.props.project.id, this.props.vocab.ERROR);
-            this.props.actions.pmHideUserGroupDeleteConfirmModal();
-        });
+            .catch(() => toast(this.props.vocab.ERROR.GROUP_DELETE,
+                { autoClose: false, type: 'error' }))
+            .then(() => {
+                this.props.actions.getProjectById(this.props.project.id, this.props.vocab.ERROR);
+                this.props.actions.pmHideUserGroupDeleteConfirmModal();
+            });
     }
+
     filterGroup(group, query) {
         return group.title.toLowerCase().includes(query.toLowerCase());
     }
+
     render() {
         const deleteModal = this.props.ui.showUserGroupDeleteConfirmModal;
         return (
             <div className='pm-user-groups-tab'>
                 {
-                    deleteModal &&
-                    <Modal title={this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.TITLE}
+                    deleteModal
+                    && <Modal title={this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.TITLE}
                         bodyText={
-                            deleteModal.dataState === NO_STAGES ?
-                            this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.DELETE_WITH_NOTHING :
-                            this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.DELETE_WITH_STAGES
+                            deleteModal.dataState === NO_STAGES
+                                ? this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.DELETE_WITH_NOTHING
+                                : this.props.vocab.MODAL.USER_GROUP_DELETE_CONFIRM.DELETE_WITH_STAGES
                         }
                         onCancel={this.props.actions.pmHideUserGroupDeleteConfirmModal}
                         onSave={this.handleDeleteModalSave}

--- a/src/views/ProjectManagement/components/Users/PMUsersTab/index.js
+++ b/src/views/ProjectManagement/components/Users/PMUsersTab/index.js
@@ -16,55 +16,63 @@ class PMUsersTab extends Component {
         this.handleDeleteClick = this.handleDeleteClick.bind(this);
         this.handleDeleteModalSave = this.handleDeleteModalSave.bind(this);
     }
+
     getDataState(userId) {
         return getDataState(userId, this.props.project.id);
     }
+
     handleDeleteClick(userId) {
         this.getDataState(userId).then((promptType) => {
             this.props.actions.pmShowUserDeleteConfirmModal(userId, promptType);
         });
     }
+
     handleDeleteModalSave() {
         this.props.actions.removeUser(
             this.props.ui.showUserDeleteConfirmModal.id,
             this.props.project.id,
-            this.props.vocab.ERROR);
+            this.props.vocab.ERROR,
+        );
         this.props.actions.pmHideUserDeleteConfirmModal();
     }
+
     filterUser(user) {
         return renderName(user).toLowerCase()
             .includes((this.props.ui.userListSearchQuery).toLowerCase());
     }
+
     handleSearchSelect(selection) {
         this.props.actions.updateUserListSearchQuery('');
         this.props.actions.addUser(
             selection.value.id,
             this.props.project.id,
-            this.props.vocab.ERROR);
+            this.props.vocab.ERROR,
+        );
     }
+
     render() {
         const deleteModal = this.props.ui.showUserDeleteConfirmModal;
         return (
             <div className='pm-users-tab'>
-                {this.props.ui.showProfile !== false &&
-                    <UserProfileContainer userId={this.props.ui.showProfile}
+                {this.props.ui.showProfile !== false
+                    && <UserProfileContainer userId={this.props.ui.showProfile}
                         projectId={this.props.project.id}
                         onCancel={() => this.props.actions.pmProjectShowProfile(false)}
                         onSave={() => this.props.actions.pmProjectShowProfile(false)}/>
                 }
                 {
-                    this.props.ui.showUserDeleteConfirmModal &&
-                    <Modal title={this.props.vocab.MODAL.USER_DELETE_CONFIRM.TITLE}
+                    this.props.ui.showUserDeleteConfirmModal
+                    && <Modal title={this.props.vocab.MODAL.USER_DELETE_CONFIRM.TITLE}
                         bodyText={
                             (
-                                deleteModal.promptType === DATA_STATE.HAS_DATA &&
-                                this.props.vocab.MODAL.USER_DELETE_CONFIRM.REMOVE_WITH_DATA
-                            ) ||
-                            (
-                                deleteModal.promptType === DATA_STATE.HAS_TASKS &&
-                                this.props.vocab.MODAL.USER_DELETE_CONFIRM.REMOVE_WITH_TASKS
-                            ) ||
-                            this.props.vocab.MODAL.USER_DELETE_CONFIRM.REMOVE_WITH_NOTHING
+                                deleteModal.promptType === DATA_STATE.HAS_DATA
+                                && this.props.vocab.MODAL.USER_DELETE_CONFIRM.REMOVE_WITH_DATA
+                            )
+                            || (
+                                deleteModal.promptType === DATA_STATE.HAS_TASKS
+                                && this.props.vocab.MODAL.USER_DELETE_CONFIRM.REMOVE_WITH_TASKS
+                            )
+                            || this.props.vocab.MODAL.USER_DELETE_CONFIRM.REMOVE_WITH_NOTHING
                         }
                         onCancel={() => this.props.actions.pmHideUserDeleteConfirmModal()}
                         onSave={this.handleDeleteModalSave}
@@ -87,10 +95,11 @@ class PMUsersTab extends Component {
                         placeHolder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
                         value={this.props.ui.userListSearchQuery}
                         list={this.props.allUsers.filter(this.filterUser)
-                            .map(user => ({ label: renderName(user),
-                                value: user }))}
-                        onChange={evt =>
-                            this.props.actions.updateUserListSearchQuery(evt.target.value)}
+                            .map(user => ({
+                                label: renderName(user),
+                                value: user,
+                            }))}
+                        onChange={evt => this.props.actions.updateUserListSearchQuery(evt.target.value)}
                         onSelect={this.handleSearchSelect}/>
                 </div>
                 <PMUserList
@@ -100,7 +109,8 @@ class PMUsersTab extends Component {
                     onUserNameClick={this.props.actions.pmProjectShowProfile}
                     onUserDeleteClick={this.handleDeleteClick}
                     onUserMailClick={id => this.props.actions.sendMessage(
-                        this.props.users.find(user => user.id === id))}/>
+                        this.props.users.find(user => user.id === id),
+                    )}/>
             </div>
         );
     }

--- a/src/views/ProjectManagement/components/Users/index.js
+++ b/src/views/ProjectManagement/components/Users/index.js
@@ -33,9 +33,9 @@ class Users extends Component {
     render() {
         return (
             <div className='users'>
-                {(this.state.modalName === 'addgroup' ||
-                    this.state.modalName === 'updategroup') &&
-                    <SelectGroupUsers
+                {(this.state.modalName === 'addgroup'
+                    || this.state.modalName === 'updategroup')
+                    && <SelectGroupUsers
                         allUsers={this.props.users}
                         users={this.props.project.users}
                         userGroups={this.props.project.userGroups}
@@ -49,7 +49,8 @@ class Users extends Component {
                                     group,
                                     this.props.project.id,
                                     this.props.profile.organizationId,
-                                    this.props.vocab.ERROR);
+                                    this.props.vocab.ERROR,
+                                );
                             } else {
                                 this.props.actions.updateUserGroup(
                                     this.state.modalId,
@@ -63,8 +64,8 @@ class Users extends Component {
                         }}/>
                 }
                 {
-                    this.state.modalName === 'adduser' &&
-                    <AddUserModal vocab={this.props.vocab}
+                    this.state.modalName === 'adduser'
+                    && <AddUserModal vocab={this.props.vocab}
                         onCancel={this.closeModal}
                         onSave={this.closeModal}
                         actions={this.props.actions}
@@ -74,7 +75,7 @@ class Users extends Component {
                 <div className='users__action-btn'>
                     <button className='users__action-btn--left'
                         onClick={this.showAddUserModal}>
-                            <span>{this.props.vocab.PROJECT.ADD_USER}</span>
+                        <span>{this.props.vocab.PROJECT.ADD_USER}</span>
                     </button>
                     <button className='users__action-btn--right'
                         onClick={this.showAddGroupModal}>
@@ -92,8 +93,7 @@ class Users extends Component {
                             vocab={this.props.vocab}
                             projectId={this.props.project.id}
                             onDeleteClick={this.props.actions.deleteUserGroup}
-                            onGroupClick={groupId =>
-                                this.setState({ modalName: 'updategroup', modalId: groupId }) }
+                            onGroupClick={groupId => this.setState({ modalName: 'updategroup', modalId: groupId }) }
                             ui={this.props.ui}
                             actions={this.props.actions}/>
                     </Tab>

--- a/src/views/ProjectManagement/components/Workflow/AssigneeContainer/AssigneeCard.js
+++ b/src/views/ProjectManagement/components/Workflow/AssigneeContainer/AssigneeCard.js
@@ -40,7 +40,6 @@ function collect(connect, monitor) {
 }
 
 class AssigneeCard extends Component {
-
     render() {
         const { isDragging, connectDragSource } = this.props;
 

--- a/src/views/ProjectManagement/components/Workflow/AssigneeContainer/InviteUser.js
+++ b/src/views/ProjectManagement/components/Workflow/AssigneeContainer/InviteUser.js
@@ -29,11 +29,11 @@ class InviteUser extends Component {
                     <button className='invite-user__button-clear'
                         onClick={this.props.onClear}>
                         {this.props.vocab.COMMON.CLEAR}
-                        </button>
+                    </button>
                     <button className='invite-user__button-invite'
                         type='submit'>
                         {this.props.vocab.COMMON.INVITE}
-                        </button>
+                    </button>
                 </div>
             </form>
         );

--- a/src/views/ProjectManagement/components/Workflow/AssigneeContainer/UserSidebar.js
+++ b/src/views/ProjectManagement/components/Workflow/AssigneeContainer/UserSidebar.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Select } from 'grommet';
+import Select from 'grommet/components/Select';
 import FilterInput from '../../../../../common/components/Dashboard/FilterInput';
 
 class UserSidebar extends Component {

--- a/src/views/ProjectManagement/components/Workflow/AssigneeContainer/index.js
+++ b/src/views/ProjectManagement/components/Workflow/AssigneeContainer/index.js
@@ -10,7 +10,6 @@ import UserSidebar from './UserSidebar';
 import { renderName } from '../../../../../utils/User';
 
 class AssigneeContainer extends Component {
-
     constructor(props) {
         super(props);
         this.onSearch = this.onSearch.bind(this);
@@ -18,13 +17,13 @@ class AssigneeContainer extends Component {
     }
 
     searchFilter(value) {
-        return !this.props.search.query ||
-            value.toLowerCase().includes(this.props.search.query.toLowerCase());
+        return !this.props.search.query
+            || value.toLowerCase().includes(this.props.search.query.toLowerCase());
     }
 
     groupFilter(unassignee) {
-        return !this.props.search.group ||
-            this.props.search.group.users.some(user => user === unassignee.id);
+        return !this.props.search.group
+            || this.props.search.group.users.some(user => user === unassignee.id);
     }
 
     onSearch(evt) {
@@ -53,8 +52,7 @@ class AssigneeContainer extends Component {
             );
         });
 
-        const groupFilters = this.props.project.userGroups.map(group =>
-            ({ label: group.title, value: group }));
+        const groupFilters = this.props.project.userGroups.map(group => ({ label: group.title, value: group }));
         groupFilters.push({ label: this.props.vocab.COMMON.ALL, value: null });
 
         return (
@@ -74,8 +72,9 @@ class AssigneeContainer extends Component {
                         this.props.project.id,
                         this.props.profile.organizationId,
                         this.props.vocab.TOAST,
-                        this.props.vocab.ERROR)}
-                    />
+                        this.props.vocab.ERROR,
+                    )}
+                />
             </Box>
         );
     }

--- a/src/views/ProjectManagement/components/Workflow/FilterWrapper.js
+++ b/src/views/ProjectManagement/components/Workflow/FilterWrapper.js
@@ -27,21 +27,20 @@ class FilterWrapper extends Component {
             <div className='filter-wrapper'>
                 <Filter filters={filters}
                     active={this.props.project.filter}
-                    onFilterClick={filter =>
-                        this.props.actions.toggleFilter(filter, this.props.project.id)}
+                    onFilterClick={filter => this.props.actions.toggleFilter(filter, this.props.project.id)}
                     noSpace={true} />
                 <div className='filter-wrapper__add-button-panel'>
                     <button className='filter-wrapper__add-button'
                         onClick={() => this.props.actions.showStageModal(true)}>
                         {this.props.vocab.PROJECT.ADD_STAGE}
-                        </button>
+                    </button>
                     <button className='filter-wrapper__add-button'
                         onClick={() => this.props.actions.showAddSubjectModal(true)}>
                         {this.props.vocab.PROJECT.ADD_SUBJECT}
-                        </button>
+                    </button>
                 </div>
-                {this.props.ui.showAddSubject &&
-                    <SubjectModal
+                {this.props.ui.showAddSubject
+                    && <SubjectModal
                         vocab={this.props.vocab}
                         onCancel={() => this.props.actions.showAddSubjectModal(false)}
                         onAddSubject={(subjects) => {
@@ -50,7 +49,8 @@ class FilterWrapper extends Component {
                                 this.props.project,
                                 subjects,
                                 false,
-                                this.props.vocab.ERROR);
+                                this.props.vocab.ERROR,
+                            );
                         }}
                     />
                 }

--- a/src/views/ProjectManagement/components/Workflow/FilteredRow.js
+++ b/src/views/ProjectManagement/components/Workflow/FilteredRow.js
@@ -6,8 +6,11 @@ import TaskStatus from '../../../../utils/TaskStatus';
 
 const _taskLookup = (stage, subjectId, tasks, responses) => {
     const newTask = Object.assign({}, tasks.find(
-        element => element.uoaId === subjectId && element.stepId === stage.id) ||
-        { stepId: stage.id, uoaId: subjectId, userIds: [], assessmentStatus: 'new', flagHistory: false });
+        element => element.uoaId === subjectId && element.stepId === stage.id,
+    )
+        || {
+            stepId: stage.id, uoaId: subjectId, userIds: [], assessmentStatus: 'new', flagHistory: false,
+        });
     const response = _.find(responses, chat => chat.taskId === newTask.id);
     if (response) newTask.response = response.discuss;
     return newTask;
@@ -19,8 +22,8 @@ class FilteredRow extends Component {
         case 'unassigned':
             return !_.isEmpty(taskData.userIds);
         case 'late':
-            return !taskData.userIds ||
-                (!(TaskStatus.endDateInPast(taskData) && taskData.status !== 'completed'));
+            return !taskData.userIds
+                || (!(TaskStatus.endDateInPast(taskData) && taskData.status !== 'completed'));
         case 'inprogress':
             return !taskData.userIds || taskData.status === 'completed' || (!taskData.flagHistory && taskData.assessmentStatus === 'new');
         case 'notstarted':
@@ -37,30 +40,27 @@ class FilteredRow extends Component {
     }
 
     render() {
-        const taskData =
-            this.props.stages.map(
-                stage => _taskLookup(stage, this.props.subject.id,
-                this.props.tasks, this.props.responses));
+        const taskData = this.props.stages.map(
+            stage => _taskLookup(stage, this.props.subject.id,
+                this.props.tasks, this.props.responses),
+        );
         return this.rowIsFilteredOut(taskData) ? null : (
             <tr key={`SubjectHeader-${this.props.subject.key}`}
                 className='filtered-row'>
-            <td key={this.props.subject.key} className='grid-subject'>
-                {this.props.subject.name}
-            </td>
-            {taskData.map(task =>
-                <td key={`StageSlot-${task.uoaId}-${task.stepId}`}
+                <td key={this.props.subject.key} className='grid-subject'>
+                    {this.props.subject.name}
+                </td>
+                {taskData.map(task => <td key={`StageSlot-${task.uoaId}-${task.stepId}`}
                     className='filtered-row__cell'>
                     <StageSlot task={task}
                         user={_.find(this.props.users, user => user.id === task.userIds[0])}
                         users={this.props.users}
                         filtered={this.taskIsFilteredOut(task)}
-                        stageData={this.props.stages.find(stage =>
-                            stage.id === task.stepId)}
+                        stageData={this.props.stages.find(stage => stage.id === task.stepId)}
                         surveySize={this.props.surveySize}
                         project={this.props.project}
                         vocab={this.props.vocab}/>
-                </td>,
-            )}
+                </td>)}
             </tr>
         );
     }

--- a/src/views/ProjectManagement/components/Workflow/MatrixContainer.js
+++ b/src/views/ProjectManagement/components/Workflow/MatrixContainer.js
@@ -13,8 +13,8 @@ class MatrixContainer extends Component {
     render() {
         return (
             <div className='matrix-container'>
-                {this.props.ui.taskOptions.show &&
-                    <TaskOptionsModal
+                {this.props.ui.taskOptions.show
+                    && <TaskOptionsModal
                         vocab={this.props.vocab}
                         task={this.props.ui.taskOptions.task}
                         userGroups={this.props.ui.taskOptions.userGroups}
@@ -22,42 +22,38 @@ class MatrixContainer extends Component {
                         profile={this.props.profile}
                         projectId={this.props.project.id}
                         actions={this.props.actions} />}
-                    <div className='matrix-container__task-matrix'>
-                        <table className='table table-bordered workflow-table'
-                            key='MatrixContainer'>
-                            <thead>
-                                <tr key={'Summary'}>
-                                    <td className='matrix-container__subject'
-                                        key='empty-subject-summary-row'>
-                                    </td>
-                                    {this.props.project.stages.map(stage =>
-                                    <td key={`StageSummary-${stage.id}`} className='stage-summary-cell'>
-                                        <StageSummary stage={stage}
-                                            onClick={() =>
-                                                this.props.actions.showStageModal(true, stage.id)}
-                                            actions={this.props.actions}
-                                            userGroups={this.props.project.userGroups}
-                                            vocab={this.props.vocab}/>
-                                    </td>)}
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {this.props.project.subjects.map((subject, key) =>
-                                    <FilteredRow key={key}
-                                      subject={{ name: subject.name, id: subject.id, key }}
-                                      surveySize={this.props.survey.questions ?
-                                          this.props.survey.questions.length : 0}
-                                      stages={this.props.project.stages}
-                                      tasks={this.props.tasks}
-                                      responses={this.props.responses}
-                                      users={this.props.users}
-                                      vocab={this.props.vocab}
-                                      project={this.props.project}
-                                      filter={this.props.project.filter}/>,
-                                )}
-                            </tbody>
-                        </table>
-                    </div>
+                <div className='matrix-container__task-matrix'>
+                    <table className='table table-bordered workflow-table'
+                        key='MatrixContainer'>
+                        <thead>
+                            <tr key={'Summary'}>
+                                <td className='matrix-container__subject'
+                                    key='empty-subject-summary-row'>
+                                </td>
+                                {this.props.project.stages.map(stage => <td key={`StageSummary-${stage.id}`} className='stage-summary-cell'>
+                                    <StageSummary stage={stage}
+                                        onClick={() => this.props.actions.showStageModal(true, stage.id)}
+                                        actions={this.props.actions}
+                                        userGroups={this.props.project.userGroups}
+                                        vocab={this.props.vocab}/>
+                                </td>)}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {this.props.project.subjects.map((subject, key) => <FilteredRow key={key}
+                                subject={{ name: subject.name, id: subject.id, key }}
+                                surveySize={this.props.survey.questions
+                                    ? this.props.survey.questions.length : 0}
+                                stages={this.props.project.stages}
+                                tasks={this.props.tasks}
+                                responses={this.props.responses}
+                                users={this.props.users}
+                                vocab={this.props.vocab}
+                                project={this.props.project}
+                                filter={this.props.project.filter}/>)}
+                        </tbody>
+                    </table>
+                </div>
                 <div className='matrix-container__sidebar'>
                     <AssigneeContainer {...this.props} />
                 </div>

--- a/src/views/ProjectManagement/components/Workflow/StageSlot.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSlot.js
@@ -22,9 +22,7 @@ const stageSpotTarget = {
         if (props.task.userId !== undefined) {
             return false;
         }
-        return flatten(props.stageData.userGroups.map(id =>
-            props.project.userGroups.find(group => group.id === id).users),
-            ).includes(monitor.getItem().id);
+        return flatten(props.stageData.userGroups.map(id => props.project.userGroups.find(group => group.id === id).users)).includes(monitor.getItem().id);
     },
     drop(props) {
         return props; // Dispatch to inform the state and DB of changes.
@@ -53,16 +51,19 @@ class StageSlot extends Component {
         this.props.actions.showTaskOptionsModal(this.props.task,
             this.props.stageData.userGroups);
     }
+
     handleSearchSelect(selection) {
         this.props.actions.assignTask(selection.suggestion.value.id,
-        { stageData: this.props.stageData, task: this.props.task },
-        this.props.project,
-        this.props.vocab);
+            { stageData: this.props.stageData, task: this.props.task },
+            this.props.project,
+            this.props.vocab);
         this.props.actions.startTaskAssign(false);
     }
+
     filterToStageGroups(user) {
         return user.usergroupId.some(groupId => this.props.stageData.userGroups.includes(groupId));
     }
+
     filterToQuery(user) {
         return renderName(user).toLowerCase().includes(this.props.assignTaskQuery.toLowerCase());
     }
@@ -70,14 +71,14 @@ class StageSlot extends Component {
     displayDueTime(done, diff) {
         if (done) {
             return '';
-        } else if (diff <= 0) {
+        } if (diff <= 0) {
             return '';
         }
         if (diff > 0 && diff < 1) {
             return this.props.vocab.PROJECT.CARD.DUE_TODAY;
-        } else if (diff >= 1 && diff < 2) {
+        } if (diff >= 1 && diff < 2) {
             return this.props.vocab.PROJECT.CARD.DUE_TOMORROW;
-        } else if (diff > 1) {
+        } if (diff > 1) {
             return this.props.vocab.PROJECT.CARD.DUE_IN + diff + this.props.vocab.PROJECT.CARD.DAYS;
         }
         return '';
@@ -93,7 +94,8 @@ class StageSlot extends Component {
         if (!this.props.task.flagHistory && this.props.task.assessmentStatus === 'new') {
             return {
                 label: this.props.vocab.PROJECT.CARD.NOT_STARTED,
-                type: StatusLabelType.NEUTRAL };
+                type: StatusLabelType.NEUTRAL,
+            };
         }
         return null;
     }
@@ -113,9 +115,9 @@ class StageSlot extends Component {
             stageClass += 'stage-slot--deny';
         }
         return connectDropTarget(
-        <div className={stageClass}>
-            {this.props.user &&
-                <div className='stage-slot__container'>
+            <div className={stageClass}>
+                {this.props.user
+                && <div className='stage-slot__container'>
                     <div className='stage-slot__name-row'>
                         <Link to={{
                             pathname: `/task-review/${this.props.project.id}/${this.props.task.id}`,
@@ -133,8 +135,8 @@ class StageSlot extends Component {
                         <span className='stage-slot__role-span'>
                             {this.props.vocab.PROJECT.CARD.ASSIGNEE}
                         </span>
-                        {this.props.task.flagged &&
-                            <div className='stage-slot__right-icon-container'>
+                        {this.props.task.flagged
+                            && <div className='stage-slot__right-icon-container'>
                                 <IonIcon className='stage-slot__right-icon' icon='ion-ios-flag'/>
                             </div>
                         }
@@ -145,42 +147,43 @@ class StageSlot extends Component {
                         </div>
                         { labelDisplay && <StatusLabel {...labelDisplay} /> }
                     </div>
-             </div>
-         }
-         {!this.props.user &&
-              <div className='stage-slot__unassigned'>
-                  { (this.props.assignTaskInput.stepId === this.props.task.stepId &&
-                     this.props.assignTaskInput.uoaId === this.props.task.uoaId) ?
-                    <div className='stage-slot__assign-task-input'>
-                        <Search
-                            fill={true}
-                            inline={true}
-                            value={this.props.assignTaskQuery}
-                            onDOMChange={evt =>
-                                this.props.actions.setAssignTaskQuery(evt.target.value)}
-                            suggestions={this.props.users
-                                .filter(this.filterToStageGroups)
-                                .filter(this.filterToQuery)
-                                .map(user => ({ label: renderName(user),
-                                    value: user }))}
-                            onSelect={this.handleSearchSelect}
-                            />
-                        <div className='stage-slot__assign-task-input-cancel'
+                </div>
+                }
+                {!this.props.user
+              && <div className='stage-slot__unassigned'>
+                  { (this.props.assignTaskInput.stepId === this.props.task.stepId
+                     && this.props.assignTaskInput.uoaId === this.props.task.uoaId)
+                      ? <div className='stage-slot__assign-task-input'>
+                          <Search
+                              fill={true}
+                              inline={true}
+                              value={this.props.assignTaskQuery}
+                              onDOMChange={evt => this.props.actions.setAssignTaskQuery(evt.target.value)}
+                              suggestions={this.props.users
+                                  .filter(this.filterToStageGroups)
+                                  .filter(this.filterToQuery)
+                                  .map(user => ({
+                                      label: renderName(user),
+                                      value: user,
+                                  }))}
+                              onSelect={this.handleSearchSelect}
+                          />
+                          <div className='stage-slot__assign-task-input-cancel'
                               onClick={() => this.props.actions.startTaskAssign(false)}>
                               x
-                        </div>
-                    </div> :
-                    <div className='inline'
-                      onClick={() => this.props.actions.startTaskAssign(this.props.task)}>
-                        <IonIcon className='stage-slot__left-icon' icon='ion-ios-plus'/>
-                        {this.props.vocab.PROJECT.CARD.ASSIGN_TASK}
-                    </div>
-                }
+                          </div>
+                      </div>
+                      : <div className='inline'
+                          onClick={() => this.props.actions.startTaskAssign(this.props.task)}>
+                          <IonIcon className='stage-slot__left-icon' icon='ion-ios-plus'/>
+                          {this.props.vocab.PROJECT.CARD.ASSIGN_TASK}
+                      </div>
+                  }
               </div>
-         }
-        {isOver && canDrop}
-        </div>,
-    );
+                }
+                {isOver && canDrop}
+            </div>,
+        );
     }
 }
 
@@ -194,6 +197,6 @@ const mapDispatchToProps = dispatch => ({
 });
 
 export default compose(
-  DropTarget(Types.ASSIGNEECARD, stageSpotTarget, collect),
-  connect(mapStateToProps, mapDispatchToProps),
+    DropTarget(Types.ASSIGNEECARD, stageSpotTarget, collect),
+    connect(mapStateToProps, mapDispatchToProps),
 )(StageSlot);

--- a/src/views/ProjectManagement/components/Workflow/StageSlot.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSlot.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { bindActionCreators, compose } from 'redux';
 import IonIcon from 'react-ionicons';
-import { Search } from 'grommet';
+import Search from 'grommet/components/Search';
 import { flatten } from 'lodash';
 
 import TaskStatus from '../../../../utils/TaskStatus';

--- a/src/views/ProjectManagement/components/Workflow/StageSummary.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSummary.js
@@ -9,8 +9,7 @@ import Time from '../../../../utils/Time';
 
 class StageSummary extends Component {
     render() {
-        const userGroups = this.props.stage.userGroups.map(stageGroup =>
-            _.find(this.props.userGroups, userGroup => userGroup.id === stageGroup));
+        const userGroups = this.props.stage.userGroups.map(stageGroup => _.find(this.props.userGroups, userGroup => userGroup.id === stageGroup));
         let permissions = 0;
         if (this.props.stage.allowEdit) {
             permissions = 3;

--- a/src/views/ProjectManagement/components/Workflow/StageSummary.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSummary.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
-import { Box } from 'grommet';
+import Box from 'grommet/components/Box';
 import _ from 'lodash';
 
 import TaskStatus from '../../../../utils/TaskStatus';

--- a/src/views/ProjectManagement/components/index.js
+++ b/src/views/ProjectManagement/components/index.js
@@ -16,7 +16,7 @@ import ProjectStatus from './Modals/ProjectStatus';
 import SurveyStatus from './Modals/SurveyStatus';
 import ProjectTitleModal from '../../../common/components/TitleChange/ProjectTitleModal';
 import SurveyTitleModal from '../../../common/components/TitleChange/SurveyTitleModal';
-import { SurveyBuilder } from '../../../views/SurveyBuilder';
+import { SurveyBuilder } from '../../SurveyBuilder';
 import * as actions from '../actions';
 import * as navActions from '../../../common/actions/navActions';
 import * as projectActions from '../../../common/actions/projectActions';
@@ -34,18 +34,19 @@ class ProjectManagementContainer extends Component {
             .then(this.props.actions.getProjectById(
                 this.props.params.projectId,
                 true,
-                this.props.vocab.ERROR));
+                this.props.vocab.ERROR,
+            ));
     }
 
     stageHasData(stageId) {
         return Promise.all(
             this.props.tasks
-            .filter(task => task.stepId === stageId &&
-                task.productId === this.props.project.productId)
-            .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId)),
+                .filter(task => task.stepId === stageId
+                && task.productId === this.props.project.productId)
+                .map(task => apiService.surveys.getAssessmentAnswersStatus(task.assessmentId)),
         )
-        .then(statuses => statuses.some(status => status !== 'new'))
-        .catch(() => toast(this.props.vocab.ERROR.STAGE_REQUEST));
+            .then(statuses => statuses.some(status => status !== 'new'))
+            .catch(() => toast(this.props.vocab.ERROR.STAGE_REQUEST));
     }
 
     handleStageDelete(stageId) {
@@ -72,7 +73,8 @@ class ProjectManagementContainer extends Component {
             body = <Users
                 vocab={this.props.vocab}
                 users={this.props.project.users.map(
-                    userId => this.props.users.find(user => user.id === userId))}
+                    userId => this.props.users.find(user => user.id === userId),
+                )}
                 allUsers={this.props.users}
                 tasks={this.props.tasks}
                 project={this.props.project}
@@ -82,13 +84,13 @@ class ProjectManagementContainer extends Component {
             break;
         case 'subject':
             body = <Subjects
-                    isOrderedByNameAscending={this.props.isOrderedByNameAscending}
-                    vocab={this.props.vocab}
-                    project={this.props.project}
-                    subjects={this.props.project.subjects}
-                    actions={this.props.actions}
-                    tasks={this.props.tasks}
-                    ui={this.props.ui}/>;
+                isOrderedByNameAscending={this.props.isOrderedByNameAscending}
+                vocab={this.props.vocab}
+                project={this.props.project}
+                subjects={this.props.project.subjects}
+                actions={this.props.actions}
+                tasks={this.props.tasks}
+                ui={this.props.ui}/>;
             break;
         case 'export':
             body = <Export vocab={this.props.vocab}
@@ -100,9 +102,10 @@ class ProjectManagementContainer extends Component {
                     this.props.actions.exportData(
                         this.props.project.productId,
                         this.props.project.name,
-                        this.props.vocab.ERROR)
-                    .then(() => toast(this.props.vocab.EXPORT.DOWNLOAD_IN_PROGRESS))
-                    .catch(() => toast(this.props.vocab.ERROR.DATA_REQUEST));
+                        this.props.vocab.ERROR,
+                    )
+                        .then(() => toast(this.props.vocab.EXPORT.DOWNLOAD_IN_PROGRESS))
+                        .catch(() => toast(this.props.vocab.ERROR.DATA_REQUEST));
                 }}/>;
             break;
         default:
@@ -110,43 +113,43 @@ class ProjectManagementContainer extends Component {
             break;
         }
         return (
-                <div>
-                    {
-                        this.props.ui.statusModalId && !this.props.ui.showInactiveConfirmModal &&
-                        (this.props.ui.statusModalId === 'projectstatusmodal' ?
-                            <ProjectStatus vocab={this.props.vocab}
+            <div>
+                {
+                    this.props.ui.statusModalId && !this.props.ui.showInactiveConfirmModal
+                        && (this.props.ui.statusModalId === 'projectstatusmodal'
+                            ? <ProjectStatus vocab={this.props.vocab}
                                 project={this.props.project}
                                 actions={this.props.actions}
-                                vocab={this.props.vocab} /> :
-                            <SurveyStatus vocab={this.props.vocab}
+                                vocab={this.props.vocab} />
+                            : <SurveyStatus vocab={this.props.vocab}
                                 survey={this.props.survey}
                                 actions={this.props.actions}
                                 vocab={this.props.vocab} />)
-                    }
-                    {
-                        this.props.ui.showInactiveConfirmModal &&
-                        <InactiveConfirm vocab={this.props.vocab}
+                }
+                {
+                    this.props.ui.showInactiveConfirmModal
+                        && <InactiveConfirm vocab={this.props.vocab}
                             project={this.props.project}
                             actions={this.props.actions} />
-                    }
-                    {
-                        this.props.ui.showProjectTitleModal &&
-                        <ProjectTitleModal vocab={this.props.vocab}
+                }
+                {
+                    this.props.ui.showProjectTitleModal
+                        && <ProjectTitleModal vocab={this.props.vocab}
                             actions={this.props.actions}
                             project={this.props.project}
                             onCloseModal={this.props.actions.pmHideProjectTitleModal}/>
-                    }
-                    {
-                        this.props.ui.showSurveyTitleModal &&
-                        <SurveyTitleModal vocab={this.props.vocab}
+                }
+                {
+                    this.props.ui.showSurveyTitleModal
+                        && <SurveyTitleModal vocab={this.props.vocab}
                             actions={this.props.actions}
                             survey={this.props.survey}
                             project={this.props.project}
                             onCloseModal={this.props.actions.pmHideSurveyTitleModal}/>
-                    }
-                    {
-                        this.props.ui.showStage && !this.props.ui.showStageDeleteConfirmModal &&
-                        <StageModal
+                }
+                {
+                    this.props.ui.showStage && !this.props.ui.showStageDeleteConfirmModal
+                        && <StageModal
                             vocab={this.props.vocab}
                             project={this.props.project}
                             stageId={this.props.ui.editStage}
@@ -158,42 +161,44 @@ class ProjectManagementContainer extends Component {
                                     this.props.project,
                                     stage,
                                     false,
-                                    this.props.vocab.ERROR);
+                                    this.props.vocab.ERROR,
+                                );
                             }}
                             userGroups={this.props.project.userGroups} />
-                    }
-                    {
-                        this.props.ui.showStageDeleteConfirmModal &&
-                        <Modal title={this.props.vocab.MODAL.STAGE_DELETE_CONFIRM.TITLE}
+                }
+                {
+                    this.props.ui.showStageDeleteConfirmModal
+                        && <Modal title={this.props.vocab.MODAL.STAGE_DELETE_CONFIRM.TITLE}
                             bodyText={this.props.vocab.MODAL.STAGE_DELETE_CONFIRM.DELETE_NO_DATA}
                             onCancel={this.props.actions.pmHideStageDeleteConfirmModal}
                             onSave={() => this.props.actions.pmDeleteStage(
                                 this.props.project.id,
-                                this.props.ui.showStageDeleteConfirmModal.stageId)
-                            .then(() => {
-                                this.props.actions.showStageModal(false);
-                                this.props.actions.pmHideStageDeleteConfirmModal();
-                            }).catch(() => {
-                                toast(this.props.vocab.ERROR.STAGE_REQUEST,
-                                    { type: 'error', autoClose: false });
-                                this.props.actions.pmHideStageDeleteConfirmModal();
-                            }) }
+                                this.props.ui.showStageDeleteConfirmModal.stageId,
+                            )
+                                .then(() => {
+                                    this.props.actions.showStageModal(false);
+                                    this.props.actions.pmHideStageDeleteConfirmModal();
+                                }).catch(() => {
+                                    toast(this.props.vocab.ERROR.STAGE_REQUEST,
+                                        { type: 'error', autoClose: false });
+                                    this.props.actions.pmHideStageDeleteConfirmModal();
+                                }) }
                             saveLabel={this.props.vocab.COMMON.DELETE} />
-                    }
-                    <Summary
-                        actions={this.props.actions}
-                        project={this.props.project}
-                        survey={this.props.survey}
-                        onStatusChangeClick={id => this.props.actions.updateStatusChange(id)}
-                        onProjectEditClick={this.props.actions.pmShowProjectTitleModal}
-                        onSurveyEditClick={this.props.actions.pmShowSurveyTitleModal}
-                        vocab={this.props.vocab}/>
-                    <SubNav vocab={this.props.vocab}
-                        subnavigate={this.props.actions.subnavigate}
-                        selected={this.props.ui.subnav}/>
-                    <hr className='divider main-divider' />
-                    {body}
-                </div>
+                }
+                <Summary
+                    actions={this.props.actions}
+                    project={this.props.project}
+                    survey={this.props.survey}
+                    onStatusChangeClick={id => this.props.actions.updateStatusChange(id)}
+                    onProjectEditClick={this.props.actions.pmShowProjectTitleModal}
+                    onSurveyEditClick={this.props.actions.pmShowSurveyTitleModal}
+                    vocab={this.props.vocab}/>
+                <SubNav vocab={this.props.vocab}
+                    subnavigate={this.props.actions.subnavigate}
+                    selected={this.props.ui.subnav}/>
+                <hr className='divider main-divider' />
+                {body}
+            </div>
         );
     }
 }
@@ -208,17 +213,19 @@ ProjectManagementContainer.propTypes = {
 
 const mapStateToProps = (store, ownProps) => {
     const projectId = parseInt(ownProps.params.projectId, 10) || store.projects[0].id;
-    const project = store.projects.data.length !== 0 ?
-        find(store.projects.data, current => current.id === projectId) :
-        store.projects.empty;
+    const project = store.projects.data.length !== 0
+        ? find(store.projects.data, current => current.id === projectId)
+        : store.projects.empty;
     return {
         project,
         tasks: store.tasks.data,
         responses: store.discuss,
         vocab: store.settings.language.vocabulary,
         ui: merge({}, store.manager.ui, store.projects.ui, store.nav.ui, store.surveys.ui),
-        survey: find(store.surveys.data, survey => survey.id === project.surveyId) ||
-            { id: -1, name: store.surveys.ui.newSurveyName, status: 'draft', sections: [] },
+        survey: find(store.surveys.data, survey => survey.id === project.surveyId)
+            || {
+                id: -1, name: store.surveys.ui.newSurveyName, status: 'draft', sections: [],
+            },
         tab: store.manager.ui.subnav,
         users: store.user.users,
         profile: store.user.profile,
@@ -234,13 +241,14 @@ const mapDispatchToProps = dispatch => ({
         surveyActions,
         taskActions,
         { addNewUser },
-        { sendMessage: user => dispatch(push(
-            {
-                pathname: '/messages/new',
-                state: { message: { to: [user.email] } },
-            },
-        )) },
-    ), dispatch),
+        {
+            sendMessage: user => dispatch(push(
+                {
+                    pathname: '/messages/new',
+                    state: { message: { to: [user.email] } },
+                },
+            )),
+        }), dispatch),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProjectManagementContainer);

--- a/src/views/ProjectManagement/reducer.js
+++ b/src/views/ProjectManagement/reducer.js
@@ -41,119 +41,177 @@ export default (state = initialState, action) => {
     case type.SUBNAVIGATE: // ui related.
         return update(state, { ui: { subnav: { $set: action.id } } });
     case type.PM_PROJECT_SHOW_PROFILE:
-        return update(state, { ui: {
-            showProfile: { $set: action.userId },
-        } });
+        return update(state, {
+            ui: {
+                showProfile: { $set: action.userId },
+            },
+        });
     case type.UPDATE_STATUS_CHANGE:
-        return update(state, { ui: {
-            statusModalId: { $set: action.status },
-            showInactiveConfirmModal: { $set: false },
-        } });
+        return update(state, {
+            ui: {
+                statusModalId: { $set: action.status },
+                showInactiveConfirmModal: { $set: false },
+            },
+        });
     case type.SHOW_INACTIVE_CONFIRM_MODAL:
-        return update(state, { ui: {
-            showInactiveConfirmModal: { $set: action.show },
-        } });
+        return update(state, {
+            ui: {
+                showInactiveConfirmModal: { $set: action.show },
+            },
+        });
     case type.UPDATE_USER_SEARCH_GROUP:
-        return (update(state, { ui: { userSidebarSearch: {
-            group: { $set: action.group },
-        } } }));
+        return (update(state, {
+            ui: {
+                userSidebarSearch: {
+                    group: { $set: action.group },
+                },
+            },
+        }));
     case type.UPDATE_USER_SEARCH_QUERY:
-        return update(state, { ui: { userSidebarSearch: {
-            query: { $set: action.query } } } });
+        return update(state, {
+            ui: {
+                userSidebarSearch: { query: { $set: action.query } },
+            },
+        });
     case type.UPDATE_USER_GROUP_LIST_SEARCH_QUERY:
-        return update(state, { ui: {
-            userGroupListSearchQuery: { $set: action.query } } });
+        return update(state, {
+            ui: { userGroupListSearchQuery: { $set: action.query } },
+        });
     case type.UPDATE_USER_LIST_SEARCH_QUERY:
-        return update(state, { ui: {
-            userListSearchQuery: { $set: action.query },
-        } });
+        return update(state, {
+            ui: {
+                userListSearchQuery: { $set: action.query },
+            },
+        });
     case type.SHOW_TASK_OPTIONS_MODAL:
-        return update(state, { ui: { taskOptions: {
-            show: { $set: true },
-            task: { $set: action.task },
-            userGroups: { $set: action.userGroups },
-        } } });
+        return update(state, {
+            ui: {
+                taskOptions: {
+                    show: { $set: true },
+                    task: { $set: action.task },
+                    userGroups: { $set: action.userGroups },
+                },
+            },
+        });
     case type.CLOSE_TASK_OPTIONS_MODAL:
-        return update(state, { ui: { taskOptions: {
-            show: { $set: false },
-            task: { $set: {} },
-            userGroups: { $set: [] },
-        } } });
+        return update(state, {
+            ui: {
+                taskOptions: {
+                    show: { $set: false },
+                    task: { $set: {} },
+                    userGroups: { $set: [] },
+                },
+            },
+        });
     case type.SHOW_SUBJECT_DELETE_CONFIRM_MODAL_FOR_ID: {
-        return update(state, { ui: {
-            showSubjectDeleteConfirmModalForId: { $set: action.id },
-        } });
+        return update(state, {
+            ui: {
+                showSubjectDeleteConfirmModalForId: { $set: action.id },
+            },
+        });
     }
     case type.PM_SHOW_USER_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showUserDeleteConfirmModal: { $set: {
-                id: action.id,
-                promptType: action.promptType,
-            } },
-        } });
+        return update(state, {
+            ui: {
+                showUserDeleteConfirmModal: {
+                    $set: {
+                        id: action.id,
+                        promptType: action.promptType,
+                    },
+                },
+            },
+        });
     }
     case type.PM_HIDE_USER_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showUserDeleteConfirmModal: { $set: null },
-        } });
+        return update(state, {
+            ui: {
+                showUserDeleteConfirmModal: { $set: null },
+            },
+        });
     }
     case type.START_TASK_ASSIGN:
-        return update(state, { ui: {
-            assignTaskInput: { $set: action.task },
-        } });
+        return update(state, {
+            ui: {
+                assignTaskInput: { $set: action.task },
+            },
+        });
     case type.SET_ASSIGN_TASK_QUERY:
-        return update(state, { ui: {
-            assignTaskQuery: { $set: action.query },
-        } });
+        return update(state, {
+            ui: {
+                assignTaskQuery: { $set: action.query },
+            },
+        });
     case type.PM_SHOW_USER_GROUP_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showUserGroupDeleteConfirmModal: { $set: {
-                id: action.id,
-                dataState: action.dataState,
-            } },
-        } });
+        return update(state, {
+            ui: {
+                showUserGroupDeleteConfirmModal: {
+                    $set: {
+                        id: action.id,
+                        dataState: action.dataState,
+                    },
+                },
+            },
+        });
     }
     case type.PM_HIDE_USER_GROUP_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showUserGroupDeleteConfirmModal: { $set: null },
-        } });
+        return update(state, {
+            ui: {
+                showUserGroupDeleteConfirmModal: { $set: null },
+            },
+        });
     }
     case type.PM_SHOW_PROJECT_TITLE_MODAL: {
-        return update(state, { ui: {
-            showProjectTitleModal: { $set: true },
-        } });
+        return update(state, {
+            ui: {
+                showProjectTitleModal: { $set: true },
+            },
+        });
     }
     case type.PM_HIDE_PROJECT_TITLE_MODAL: {
-        return update(state, { ui: {
-            showProjectTitleModal: { $set: false },
-        } });
+        return update(state, {
+            ui: {
+                showProjectTitleModal: { $set: false },
+            },
+        });
     }
     case type.PM_SHOW_SURVEY_TITLE_MODAL: {
-        return update(state, { ui: {
-            showSurveyTitleModal: { $set: true },
-        } });
+        return update(state, {
+            ui: {
+                showSurveyTitleModal: { $set: true },
+            },
+        });
     }
     case type.PM_HIDE_SURVEY_TITLE_MODAL: {
-        return update(state, { ui: {
-            showSurveyTitleModal: { $set: false },
-        } });
+        return update(state, {
+            ui: {
+                showSurveyTitleModal: { $set: false },
+            },
+        });
     }
     case type.SHOW_STAGE_MODAL:
-        return update(state, { ui: {
-            showStage: { $set: action.show },
-            editStage: { $set: action.stageId !== undefined ? action.stageId : null },
-        } });
+        return update(state, {
+            ui: {
+                showStage: { $set: action.show },
+                editStage: { $set: action.stageId !== undefined ? action.stageId : null },
+            },
+        });
     case type.PM_SHOW_STAGE_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showStageDeleteConfirmModal: { $set: {
-                stageId: action.stageId,
-            } },
-        } });
+        return update(state, {
+            ui: {
+                showStageDeleteConfirmModal: {
+                    $set: {
+                        stageId: action.stageId,
+                    },
+                },
+            },
+        });
     }
     case type.PM_HIDE_STAGE_DELETE_CONFIRM_MODAL: {
-        return update(state, { ui: {
-            showStageDeleteConfirmModal: { $set: null },
-        } });
+        return update(state, {
+            ui: {
+                showStageDeleteConfirmModal: { $set: null },
+            },
+        });
     }
     case type.PM_PROJECT_SUBJECTS_ORDER_BY_NAME_ASC:
         return update(state, {

--- a/src/views/ResetPassword/components/actions.js
+++ b/src/views/ResetPassword/components/actions.js
@@ -2,6 +2,5 @@ import { push } from 'react-router-redux';
 
 import apiService from '../../../services/api';
 
-export const resetPassword = (token, password) => dispatch =>
-apiService.auth.resetPassword(token, password)
-.then(() => dispatch(push('/login')));
+export const resetPassword = (token, password) => dispatch => apiService.auth.resetPassword(token, password)
+    .then(() => dispatch(push('/login')));

--- a/src/views/ResetPassword/components/index.js
+++ b/src/views/ResetPassword/components/index.js
@@ -10,8 +10,7 @@ class ResetPasswordContainer extends Component {
     render() {
         return (
             <ResetPasswordForm {...this.props}
-                onSubmit={({ password }) =>
-                    this.props.actions.resetPassword(this.props.token, password)
+                onSubmit={({ password }) => this.props.actions.resetPassword(this.props.token, password)
                     .then(() => toast(this.props.vocab.RESET_PASSWORD.PASSWORD_RESET_SUCCESS))
                     .catch(err => toast(err.message, { type: 'error', autoClose: false }))
                 }/>

--- a/src/views/SurveyBuilder/components/AddQuestionPanel/ExistingQuestions.js
+++ b/src/views/SurveyBuilder/components/AddQuestionPanel/ExistingQuestions.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 class ExistingQuestions extends Component {
-
     render() {
         return (
             <div className='existing-questions'>

--- a/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
+++ b/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { keys } from 'lodash';
-import { Menu } from 'grommet';
+import Menu from 'grommet/components/Menu';
 import IonIcon from 'react-ionicons';
 import PropTypes from 'prop-types';
 

--- a/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
+++ b/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
@@ -35,26 +35,23 @@ class NewQuestions extends Component {
                     return (
                         <div className='new-questions__types'
                             key={`question-type${type}`}>
-                                {this.props.vocab.SURVEY.QUESTIONS_TYPES[type]}
-                            {this.props.sectionView < 0 ?
-                                    <Menu responsive={true}
-                                        icon={<IonIcon icon='ion-ios-plus'
-                                            className='new-questions__icon'/>}>
-                                        <span className='new-questions__insert-label'>
-                                            {this.props.vocab.SURVEY.INSERT_INTO}
-                                        </span>
-                                        <div className='new-questions__menu-dropdown'>
-                                            {this.props.options.map(option =>
-                                                <div className='new-questions__menu-button'
-                                                    key={`question-menu${type}${option.value}`}
-                                                    onClick={() =>
-                                                        this.handleInsert(type, option.value)}>
-                                                    {option.label}
-                                                </div>,
-                                            )}
-                                        </div>
-                                    </Menu> :
-                                <button className='new-questions__masked-button'
+                            {this.props.vocab.SURVEY.QUESTIONS_TYPES[type]}
+                            {this.props.sectionView < 0
+                                ? <Menu responsive={true}
+                                    icon={<IonIcon icon='ion-ios-plus'
+                                        className='new-questions__icon'/>}>
+                                    <span className='new-questions__insert-label'>
+                                        {this.props.vocab.SURVEY.INSERT_INTO}
+                                    </span>
+                                    <div className='new-questions__menu-dropdown'>
+                                        {this.props.options.map(option => <div className='new-questions__menu-button'
+                                            key={`question-menu${type}${option.value}`}
+                                            onClick={() => this.handleInsert(type, option.value)}>
+                                            {option.label}
+                                        </div>)}
+                                    </div>
+                                </Menu>
+                                : <button className='new-questions__masked-button'
                                     onClick={() => this.handleInsert(type, this.props.sectionView)}>
                                     <IonIcon icon='ion-ios-plus'
                                         className='new-questions__icon'/>

--- a/src/views/SurveyBuilder/components/CreateSectionPanel.js
+++ b/src/views/SurveyBuilder/components/CreateSectionPanel.js
@@ -14,17 +14,19 @@ class CreateSectionPanel extends Component {
                     <input className='create-section-panel__section-name'
                         type='text'
                         defaultValue={this.props.section.name}
-                        placeholder={this.props.vocab.SURVEY.SECTION_ +
-                            (this.props.sectionIndex + 1) + this.props.vocab.SURVEY.NAME}
+                        placeholder={this.props.vocab.SURVEY.SECTION_
+                            + (this.props.sectionIndex + 1) + this.props.vocab.SURVEY.NAME}
                         onChange={event => this.props.actions.updateSection(
-                            this.props.sectionIndex, event.target.value)} />
+                            this.props.sectionIndex, event.target.value,
+                        )} />
                     <button className='create-section-panel__menu-button'
                         onClick={() => {
                             if (this.props.sectionLength <= 1) {
                                 toast(this.props.vocab.ERROR.SECTION_MINIMUM);
                             } else {
                                 this.props.actions.showSectionDeleteConfirmModal(
-                            this.props.sectionIndex);
+                                    this.props.sectionIndex,
+                                );
                             }
                         }}>
                         <IonIcon icon='ion-trash-b'

--- a/src/views/SurveyBuilder/components/CreateSurveyPanel.js
+++ b/src/views/SurveyBuilder/components/CreateSurveyPanel.js
@@ -11,78 +11,79 @@ class CreateSurveyPanel extends Component {
     render() {
         return (
             <div className='create-survey-panel'>
-                {this.props.ui.showSectionDeleteConfirmModal > -1 &&
-                <Modal title={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.TITLE}
-                       bodyText={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.DELETE_WARNING}
-                       onCancel={() => this.props.actions.showSectionDeleteConfirmModal(-1)}
-                       onSave={() => {
-                           this.props.actions.deleteSection(
-                               this.props.ui.showSectionDeleteConfirmModal);
-                           this.props.actions.showSectionDeleteConfirmModal(-1);
-                       }}
-                       saveLabel={this.props.vocab.COMMON.DELETE}/>}
+                {this.props.ui.showSectionDeleteConfirmModal > -1
+                && <Modal title={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.TITLE}
+                    bodyText={this.props.vocab.MODAL.SECTION_DELETE_CONFIRM.DELETE_WARNING}
+                    onCancel={() => this.props.actions.showSectionDeleteConfirmModal(-1)}
+                    onSave={() => {
+                        this.props.actions.deleteSection(
+                            this.props.ui.showSectionDeleteConfirmModal,
+                        );
+                        this.props.actions.showSectionDeleteConfirmModal(-1);
+                    }}
+                    saveLabel={this.props.vocab.COMMON.DELETE}/>}
                 <div className='create-survey-panel__view-controls'>
                     <Select className='create-survey-panel__view-select'
-                            options={this.props.options}
-                            value={this.props.ui.sectionView}
-                            clearable={false}
-                            disabled={this.props.options.length === 1}
-                            onChange={event => this.props.actions.changeSectionView(event.value)}/>
+                        options={this.props.options}
+                        value={this.props.ui.sectionView}
+                        clearable={false}
+                        disabled={this.props.options.length === 1}
+                        onChange={event => this.props.actions.changeSectionView(event.value)}/>
                     <div className='create-survey-panel__accordion-buttons'>
                         <button className='create-survey-panel__button-expand'
-                                onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
+                            onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
                             {this.props.vocab.PROJECT.EXPAND_ALL}
                         </button>
                         <button className='create-survey-panel__button-collapse'
-                                onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
+                            onClick={() => toast(this.props.vocab.ERROR.COMING_SOON)}>
                             {this.props.vocab.PROJECT.COLLAPSE_ALL}
                         </button>
                     </div>
                 </div>
                 <div className='create-survey-panel__survey-controls'>
                     <button className='create-survey-panel__survey-save'
-                            onClick={() => {
-                                const blanks = some(this.props.form.sections, (section) => {
-                                    return some(section.questions, (question) => {
-                                        if (question.text.match(/^\s*$/) !== null) {
-                                            return true;
-                                        }
-                                        if (has(question, 'choices')) {
-                                            return some(question.choices, choice => choice.text.match(/^\s*$/) !== null);
-                                        }
-                                        return false;
-                                    });
+                        onClick={() => {
+                            const blanks = some(this.props.form.sections, (section) => {
+                                return some(section.questions, (question) => {
+                                    if (question.text.match(/^\s*$/) !== null) {
+                                        return true;
+                                    }
+                                    if (has(question, 'choices')) {
+                                        return some(question.choices, choice => choice.text.match(/^\s*$/) !== null);
+                                    }
+                                    return false;
                                 });
-                                const blankSection = some(this.props.form.sections, (section) => {
-                                    return (section.name.match(/^\s*$/) !== null);
-                                });
-                                if (blanks) {
-                                    toast(this.props.vocab.ERROR.BLANKS);
-                                }
-                                if (blankSection) {
-                                    toast(this.props.vocab.ERROR.BLANK_SECTION);
-                                }
-                                if (!blanks && !blankSection) {
-                                    this.props.actions.patchSurvey(
-                                        this.props.form,
-                                        this.props.vocab.SURVEY.SUCCESS,
-                                        this.props.vocab.ERROR);
-                                }
-                            }}>
+                            });
+                            const blankSection = some(this.props.form.sections, (section) => {
+                                return (section.name.match(/^\s*$/) !== null);
+                            });
+                            if (blanks) {
+                                toast(this.props.vocab.ERROR.BLANKS);
+                            }
+                            if (blankSection) {
+                                toast(this.props.vocab.ERROR.BLANK_SECTION);
+                            }
+                            if (!blanks && !blankSection) {
+                                this.props.actions.patchSurvey(
+                                    this.props.form,
+                                    this.props.vocab.SURVEY.SUCCESS,
+                                    this.props.vocab.ERROR,
+                                );
+                            }
+                        }}>
                         {this.props.vocab.SURVEY.SAVE_PROGRESS}
                     </button>
                 </div>
                 <div className='create-survey-panel__instructions'>
                     {this.props.vocab.PROJECT.INSTRUCTIONS}
                     <textarea className='create-survey-panel__instructions-entry'
-                              placeholder={this.props.vocab.SURVEY.ENTER_INSTRUCTIONS}
-                              value={this.props.form.description}
-                              onChange={event =>
-                                  this.props.actions.updateInstructions(event.target.value)}/>
+                        placeholder={this.props.vocab.SURVEY.ENTER_INSTRUCTIONS}
+                        value={this.props.form.description}
+                        onChange={event => this.props.actions.updateInstructions(event.target.value)}/>
                 </div>
                 <div className='create-survey-panel__sections-list'>
-                    {this.props.ui.sectionView === -1 ?
-                        this.props.form.sections.map((section, sectionIndex) => (
+                    {this.props.ui.sectionView === -1
+                        ? this.props.form.sections.map((section, sectionIndex) => (
                             <CreateSectionPanel
                                 key={`key-section-${sectionIndex}`}
                                 ui={this.props.ui}
@@ -91,8 +92,8 @@ class CreateSurveyPanel extends Component {
                                 sectionLength={this.props.form.sections.length}
                                 actions={this.props.actions}
                                 vocab={this.props.vocab}/>
-                        )) :
-                        <CreateSectionPanel
+                        ))
+                        : <CreateSectionPanel
                             ui={this.props.ui}
                             section={this.props.form.sections[this.props.ui.sectionView]}
                             sectionIndex={this.props.ui.sectionView}

--- a/src/views/SurveyBuilder/components/DynamicQuestion.js
+++ b/src/views/SurveyBuilder/components/DynamicQuestion.js
@@ -35,73 +35,72 @@ class DynamicQuestion extends Component {
                                 this.props.actions.upsertScale(this.props.sectionIndex,
                                     this.props.questionIndex, true, value);
                             }} />
-                        </div>
-                        <div className='dynamic-question__scale-field'>
-                            <span className='dynamic-question__scale-label'>
-                                {this.props.vocab.SURVEY.SCALE_VALUES.MIN}
-                            </span>
-                            <input className='dynamic-question__scale-input'
-                                type='number'
-                                placeholder={0}
-                                max={get(this.props.question, 'scaleLimits.max', 10) - 1}
-                                value={get(this.props.question, 'scaleLimits.min', '')}
-                                onChange={(event) => {
-                                    this.props.actions.upsertScale(this.props.sectionIndex,
-                                        this.props.questionIndex,
-                                        false,
-                                        parseInt(event.target.value, 10));
-                                }}
-                                onBlur={(event) => {
-                                    let value = parseInt(event.target.value, 10);
-                                    const maxValue = get(this.props.question, 'scaleLimits.max', 10);
-                                    if (value > maxValue) {
-                                        toast(this.props.vocab.ERROR.MIN_MAX_INVALID);
-                                        value = maxValue - 1;
-                                    }
-                                    this.props.actions.upsertScale(this.props.sectionIndex,
-                                        this.props.questionIndex, false, value);
-                                }} />
-                            </div>
+                    </div>
+                    <div className='dynamic-question__scale-field'>
+                        <span className='dynamic-question__scale-label'>
+                            {this.props.vocab.SURVEY.SCALE_VALUES.MIN}
+                        </span>
+                        <input className='dynamic-question__scale-input'
+                            type='number'
+                            placeholder={0}
+                            max={get(this.props.question, 'scaleLimits.max', 10) - 1}
+                            value={get(this.props.question, 'scaleLimits.min', '')}
+                            onChange={(event) => {
+                                this.props.actions.upsertScale(this.props.sectionIndex,
+                                    this.props.questionIndex,
+                                    false,
+                                    parseInt(event.target.value, 10));
+                            }}
+                            onBlur={(event) => {
+                                let value = parseInt(event.target.value, 10);
+                                const maxValue = get(this.props.question, 'scaleLimits.max', 10);
+                                if (value > maxValue) {
+                                    toast(this.props.vocab.ERROR.MIN_MAX_INVALID);
+                                    value = maxValue - 1;
+                                }
+                                this.props.actions.upsertScale(this.props.sectionIndex,
+                                    this.props.questionIndex, false, value);
+                            }} />
+                    </div>
                 </div>);
         } else {
             QuestionDisplay = (
                 <div className={'dynamic-question__choices'}>
-                    {this.props.question.choices.map((choice, index) =>
-                        <div className='dynamic-question__choices-fields'
-                            key={this.props.sectionIndex + this.props.questionIndex +
-                                this.props.question.type + index}>
-                            <div className='dynamic-question__choices-group'>
-                                <input className='dynamic-question__choices__input'
-                                    type='text'
-                                    placeholder={this.props.vocab.SURVEY.CHOICE_ENTER}
-                                    value={choice.text || ''}
-                                    onChange={event => this.props.actions.upsertChoice(
-                                        this.props.sectionIndex,
-                                        this.props.questionIndex,
-                                        index,
-                                        event.target.value,
-                                    )} />
-                                <button className='dynamic-question__masked-button'
-                                    onClick={() => this.props.actions.upsertChoice(
-                                        this.props.sectionIndex,
-                                        this.props.questionIndex,
-                                        index,
-                                        )}>
-                                    <IonIcon icon='ion-ios-plus'
-                                        className='dynamic-question__icon'/>
-                                </button>
-                                <button className='dynamic-question__masked-button'
-                                    onClick={() => this.props.actions.deleteChoice(
-                                        this.props.sectionIndex,
-                                        this.props.questionIndex,
-                                        index,
-                                        )}>
-                                    <IonIcon icon='ion-trash-b'
-                                        className='dynamic-question__icon'/>
-                                </button>
-                            </div>
-                            {has(this.props.question, 'meta.weight') &&
-                                <input className='dynamic-question__weight-input'
+                    {this.props.question.choices.map((choice, index) => <div className='dynamic-question__choices-fields'
+                        key={this.props.sectionIndex + this.props.questionIndex
+                                + this.props.question.type + index}>
+                        <div className='dynamic-question__choices-group'>
+                            <input className='dynamic-question__choices__input'
+                                type='text'
+                                placeholder={this.props.vocab.SURVEY.CHOICE_ENTER}
+                                value={choice.text || ''}
+                                onChange={event => this.props.actions.upsertChoice(
+                                    this.props.sectionIndex,
+                                    this.props.questionIndex,
+                                    index,
+                                    event.target.value,
+                                )} />
+                            <button className='dynamic-question__masked-button'
+                                onClick={() => this.props.actions.upsertChoice(
+                                    this.props.sectionIndex,
+                                    this.props.questionIndex,
+                                    index,
+                                )}>
+                                <IonIcon icon='ion-ios-plus'
+                                    className='dynamic-question__icon'/>
+                            </button>
+                            <button className='dynamic-question__masked-button'
+                                onClick={() => this.props.actions.deleteChoice(
+                                    this.props.sectionIndex,
+                                    this.props.questionIndex,
+                                    index,
+                                )}>
+                                <IonIcon icon='ion-trash-b'
+                                    className='dynamic-question__icon'/>
+                            </button>
+                        </div>
+                        {has(this.props.question, 'meta.weight')
+                                && <input className='dynamic-question__weight-input'
                                     placeholder={0}
                                     defaultValue={get(this.props.question, `choices[${index}].weight`, undefined)}
                                     onBlur={event => this.props.actions.upsertWeight(
@@ -109,18 +108,17 @@ class DynamicQuestion extends Component {
                                         this.props.questionIndex,
                                         index,
                                         event.target.value,
-                                        )} />
-                            }
-                        </div>,
-                            )}
+                                    )} />
+                        }
+                    </div>)}
                 </div>);
         }
         return (
             <div className='dynamic-question'>
                 <div className='dynamic-question__instructions'>
-                    {get(this.props.question, 'meta.subType') === 'dropdown' ?
-                        this.props.vocab.SURVEY.QUESTIONS_EXPLAINED.DROPDOWN :
-                        this.props.vocab.SURVEY.QUESTIONS_EXPLAINED[
+                    {get(this.props.question, 'meta.subType') === 'dropdown'
+                        ? this.props.vocab.SURVEY.QUESTIONS_EXPLAINED.DROPDOWN
+                        : this.props.vocab.SURVEY.QUESTIONS_EXPLAINED[
                             this.props.question.type.toUpperCase()]}
                 </div>
                 {QuestionDisplay}

--- a/src/views/SurveyBuilder/components/QuestionPanel.js
+++ b/src/views/SurveyBuilder/components/QuestionPanel.js
@@ -14,7 +14,7 @@ class QuestionPanel extends Component {
                 <div className='question-panel__top'>
                     <div className= 'question-panel__menu'>
                         <div className='question-panel__question-number'>
-                        {`${this.props.vocab.PROJECT.QUESTION_ + (this.props.questionIndex + 1)}: `}
+                            {`${this.props.vocab.PROJECT.QUESTION_ + (this.props.questionIndex + 1)}: `}
                         </div>
                         <div className='question-panel__top-right'>
                             <button className='question-panel__menu-button'
@@ -22,18 +22,20 @@ class QuestionPanel extends Component {
                                     this.props.sectionIndex,
                                     this.props.questionIndex,
                                     -1,
-                                    this.props.vocab.ERROR)}>
-                                    <IonIcon icon='ion-arrow-up-c'
-                                        className='question-panel__menu-icon'/>
+                                    this.props.vocab.ERROR,
+                                )}>
+                                <IonIcon icon='ion-arrow-up-c'
+                                    className='question-panel__menu-icon'/>
                             </button>
                             <button className='question-panel__menu-button'
                                 onClick={() => this.props.actions.moveQuestion(
                                     this.props.sectionIndex,
                                     this.props.questionIndex,
                                     1,
-                                    this.props.vocab.ERROR)}>
-                                    <IonIcon icon='ion-arrow-down-c'
-                                        className='question-panel__menu-icon'/>
+                                    this.props.vocab.ERROR,
+                                )}>
+                                <IonIcon icon='ion-arrow-down-c'
+                                    className='question-panel__menu-icon'/>
                             </button>
                             <button className='question-panel__menu-button'
                                 onClick={() => this.props.actions.deleteQuestion(
@@ -59,9 +61,9 @@ class QuestionPanel extends Component {
                             )} />
                     </div>
                 </div>
-                {DYNAMIC.includes(this.props.question.type) ?
-                    <DynamicQuestion {...this.props} /> :
-                    <StaticQuestion
+                {DYNAMIC.includes(this.props.question.type)
+                    ? <DynamicQuestion {...this.props} />
+                    : <StaticQuestion
                         type={this.props.question.type}
                         vocab={this.props.vocab}/>
                 }
@@ -76,40 +78,44 @@ class QuestionPanel extends Component {
                                             this.props.sectionIndex,
                                             this.props.questionIndex,
                                             'meta',
-                                            { file: true });
+                                            { file: true },
+                                        );
                                     } else {
                                         this.props.actions.resetMeta(
                                             this.props.sectionIndex,
                                             this.props.questionIndex,
-                                            'file');
+                                            'file',
+                                        );
                                     }
                                 }} />
                             <IonIcon icon='ion-paperclip'
                                 className='question-panel__attach-icon' />
                             <span className='question-panel__icon-label'
-                            title= {this.props.vocab.SURVEY.ATTACH_TOOLTIP}>
+                                title= {this.props.vocab.SURVEY.ATTACH_TOOLTIP}>
                                 {this.props.vocab.SURVEY.ATTACH_FILE}
                             </span>
                         </div>
                         <div className='question-panel__checkboxes'>
-                        <input type='checkbox'
-                            checked={has(this.props.question, 'meta.publication')}
-                            onChange={(event) => {
-                                if (event.target.checked) {
-                                    this.props.actions.updateQuestion(
-                                        this.props.sectionIndex,
-                                        this.props.questionIndex,
-                                        'meta',
-                                        { publication: {} });
-                                } else {
-                                    this.props.actions.resetMeta(
-                                        this.props.sectionIndex,
-                                        this.props.questionIndex,
-                                        'publication');
-                                }
-                            }} />
+                            <input type='checkbox'
+                                checked={has(this.props.question, 'meta.publication')}
+                                onChange={(event) => {
+                                    if (event.target.checked) {
+                                        this.props.actions.updateQuestion(
+                                            this.props.sectionIndex,
+                                            this.props.questionIndex,
+                                            'meta',
+                                            { publication: {} },
+                                        );
+                                    } else {
+                                        this.props.actions.resetMeta(
+                                            this.props.sectionIndex,
+                                            this.props.questionIndex,
+                                            'publication',
+                                        );
+                                    }
+                                }} />
                             <span className='question-panel__label'
-                            title= {this.props.vocab.SURVEY.LINK_TOOLTIP}>
+                                title= {this.props.vocab.SURVEY.LINK_TOOLTIP}>
                                 {this.props.vocab.SURVEY.ADD_A_LINK}
                             </span>
                         </div>
@@ -120,15 +126,16 @@ class QuestionPanel extends Component {
                                     this.props.sectionIndex,
                                     this.props.questionIndex,
                                     'required',
-                                    event.target.checked)} />
+                                    event.target.checked,
+                                )} />
                             <span className='question-panel__label'
-                            title= {this.props.vocab.SURVEY.REQUIRED_TOOLTIP}>
+                                title= {this.props.vocab.SURVEY.REQUIRED_TOOLTIP}>
                                 {this.props.vocab.SURVEY.REQUIRED_QUESTION}
                             </span>
                         </div>
                     </div>
-                    {WEIGHTED.includes(this.props.question.type) &&
-                        <div className='question-panel__checkboxes'>
+                    {WEIGHTED.includes(this.props.question.type)
+                        && <div className='question-panel__checkboxes'>
                             <input type='checkbox'
                                 checked={has(this.props.question, 'meta.weight')}
                                 onChange={(event) => {
@@ -137,12 +144,14 @@ class QuestionPanel extends Component {
                                             this.props.sectionIndex,
                                             this.props.questionIndex,
                                             'meta',
-                                            { weight: true });
+                                            { weight: true },
+                                        );
                                     } else {
                                         this.props.actions.resetMeta(
                                             this.props.sectionIndex,
                                             this.props.questionIndex,
-                                            'weight');
+                                            'weight',
+                                        );
                                     }
                                 }}/>
                             <span className='question-panel__label'

--- a/src/views/SurveyBuilder/components/index.js
+++ b/src/views/SurveyBuilder/components/index.js
@@ -11,20 +11,21 @@ import CreateSurveyPanel from './CreateSurveyPanel';
 
 class SurveyBuilder extends Component {
     render() {
-        const options = this.props.form.sections ?
-            this.props.form.sections.map((section, index) =>
-                ({ value: index,
-                    label: (section.name ||
-                    this.props.vocab.SURVEY.SECTION_ + (index + 1)) })) : [];
+        const options = this.props.form.sections
+            ? this.props.form.sections.map((section, index) => ({
+                value: index,
+                label: (section.name
+                    || this.props.vocab.SURVEY.SECTION_ + (index + 1)),
+            })) : [];
         const allOptions = cloneDeep(options);
         allOptions.unshift({ value: -1, label: this.props.vocab.SURVEY.VIEW_ALL });
         return (
             <div className='survey-builder'>
-                    {
-                    this.props.form.status === 'published' &&
-                    <div className='survey-builder__draft-warning'>
-                    {this.props.vocab.SURVEY.DRAFT_WARNING}</div>
-                    }
+                {
+                    this.props.form.status === 'published'
+                    && <div className='survey-builder__draft-warning'>
+                        {this.props.vocab.SURVEY.DRAFT_WARNING}</div>
+                }
                 <div className={`survey-builder__contents survey-builder__contents--${this.props.form.status === 'draft' ? 'draft' : 'published'}`} >
                     <AddQuestionPanel className='survey-builder__add-question'
                         sectionView={this.props.ui.sectionView}

--- a/src/views/SurveyBuilder/reducer.js
+++ b/src/views/SurveyBuilder/reducer.js
@@ -1,5 +1,7 @@
 import update from 'immutability-helper';
-import { assign, cloneDeep, has, omit } from 'lodash';
+import {
+    assign, cloneDeep, has, omit,
+} from 'lodash';
 import { toast } from 'react-toastify';
 
 import * as type from './actionTypes';
@@ -7,7 +9,7 @@ import {
     GET_SURVEY_BY_ID_SUCCESS,
     POST_SURVEY_SUCCESS,
     PATCH_SURVEY_SUCCESS,
- } from '../../common/actionTypes/surveyActionTypes';
+} from '../../common/actionTypes/surveyActionTypes';
 
 export const initialState = {
     ui: {
@@ -29,8 +31,10 @@ export default (state = initialState, action) => {
     case GET_SURVEY_BY_ID_SUCCESS: {
         if (action.survey.id) {
             if (action.survey.questions) {
-                const newSurvey = assign({}, action.survey, { sections: [
-                    { name: '', questions: action.survey.questions }] });
+                const newSurvey = assign({}, action.survey, {
+                    sections: [
+                        { name: '', questions: action.survey.questions }],
+                });
                 delete newSurvey.questions;
                 return update(state, { form: { $set: newSurvey } });
             }
@@ -39,84 +43,205 @@ export default (state = initialState, action) => {
         return initialState;
     }
     case POST_SURVEY_SUCCESS:
-        return update(state, { form: { id: { $set: action.survey.id },
-            sections: { $set: [{ name: '', questions: [] }] } } });
+        return update(state, {
+            form: {
+                id: { $set: action.survey.id },
+                sections: { $set: [{ name: '', questions: [] }] },
+            },
+        });
     case PATCH_SURVEY_SUCCESS: // Not sure I want forceStatus coming back.
         return update(state, { form: { $merge: action.survey } });
     case type.SURVEY_BUILDER_CHANGE_SECTION_VIEW:
         return update(state, { ui: { sectionView: { $set: action.sectionView } } });
     case type.SURVEY_BUILDER_SHOW_SECTION_DELETE_CONFIRM_MODAL:
-        return update(state, { ui: { showSectionDeleteConfirmModal: { $set:
-            action.sectionIndex } } });
+        return update(state, {
+            ui: {
+                showSectionDeleteConfirmModal: {
+                    $set:
+            action.sectionIndex,
+                },
+            },
+        });
     case type.SURVEY_BUILDER_UPDATE_INSTRUCTIONS:
         return update(state, { form: { description: { $set: action.instructions } } });
     case type.SURVEY_BUILDER_INSERT_SECTION:
         return update(state, { form: { sections: { $push: [{ name: '', questions: [] }] } } });
     case type.SURVEY_BUILDER_UPDATE_SECTION:
-        return update(state, { form: { sections: { [action.sectionIndex]:
-            { name: { $set: action.name } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+            { name: { $set: action.name } },
+                },
+            },
+        });
     case type.SURVEY_BUILDER_DELETE_SECTION:
         return update(state, { form: { sections: { $splice: [[action.sectionIndex, 1]] } } });
     case type.SURVEY_BUILDER_INSERT_QUESTION: {
         if (has(state.form, `sections[${action.sectionIndex}].questions`)) {
-            return update(state, { form: { sections: { [action.sectionIndex]:
-            { questions: { $push: [action.question] } } } } });
+            return update(state, {
+                form: {
+                    sections: {
+                        [action.sectionIndex]:
+            { questions: { $push: [action.question] } },
+                    },
+                },
+            });
         }
-        return update(state, { form: { sections: { [action.sectionIndex]: { $set: {
-            questions: [action.question] } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]: {
+                        $set: { questions: [action.question] },
+                    },
+                },
+            },
+        });
     }
     case type.SURVEY_BUILDER_UPDATE_QUESTION: {
         if (action.field === 'meta' && state.form.sections[action.sectionIndex].questions[action.questionIndex].meta) {
-            return update(state, { form: { sections: { [action.sectionIndex]:
-            { questions: { [action.questionIndex]: { [action.field]:
-                { $merge: action.value } } },
-                $unset: ['id'] } } } });
+            return update(state, {
+                form: {
+                    sections: {
+                        [action.sectionIndex]:
+            {
+                questions: {
+                    [action.questionIndex]: {
+                        [action.field]:
+                { $merge: action.value },
+                    },
+                },
+                $unset: ['id'],
+            },
+                    },
+                },
+            });
         }
-        const newState = update(state, { form: { sections: { [action.sectionIndex]:
-        { questions: { [action.questionIndex]: { [action.field]:
+        const newState = update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+        {
+            questions: {
+                [action.questionIndex]: {
+                    [action.field]:
             { $set: action.value },
-            $unset: ['id'] } } } } } });
+                    $unset: ['id'],
+                },
+            },
+        },
+                },
+            },
+        });
         if (has(state.form.sections[action.sectionIndex].questions[action.questionIndex], 'choices')) {
-            return update(newState, { form: { sections: { [action.sectionIndex]:
-            { questions: { [action.questionIndex]: {
-                choices: { $apply: choices => choices.map(choice => omit(choice, ['id'])) } } } } } } });
+            return update(newState, {
+                form: {
+                    sections: {
+                        [action.sectionIndex]:
+            {
+                questions: {
+                    [action.questionIndex]: { choices: { $apply: choices => choices.map(choice => omit(choice, ['id'])) } },
+                },
+            },
+                    },
+                },
+            });
         }
         return newState;
     }
     case type.SURVEY_BUILDER_UPSERT_CHOICE: {
         if (action.value !== undefined) {
-            return update(state, { form: { sections: { [action.sectionIndex]:
-            { questions: { [action.questionIndex]: { choices: {
-                $apply: choices => choices.map(choice => omit(choice, ['id'])),
-                [action.choiceIndex]: { text: { $set: action.value } } },
-                $unset: ['id'] } } } } } });
+            return update(state, {
+                form: {
+                    sections: {
+                        [action.sectionIndex]:
+            {
+                questions: {
+                    [action.questionIndex]: {
+                        choices: {
+                            $apply: choices => choices.map(choice => omit(choice, ['id'])),
+                            [action.choiceIndex]: { text: { $set: action.value } },
+                        },
+                        $unset: ['id'],
+                    },
+                },
+            },
+                    },
+                },
+            });
         }
-        return update(state, { form: { sections: { [action.sectionIndex]:
-        { questions: { [action.questionIndex]: { choices: {
-            $apply: choices => choices.map(choice => omit(choice, ['id'])),
-            $splice: [[action.choiceIndex + 1, 0, { text: '' }]] } } },
-            $unset: ['id'] } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+        {
+            questions: {
+                [action.questionIndex]: {
+                    choices: {
+                        $apply: choices => choices.map(choice => omit(choice, ['id'])),
+                        $splice: [[action.choiceIndex + 1, 0, { text: '' }]],
+                    },
+                },
+            },
+            $unset: ['id'],
+        },
+                },
+            },
+        });
     }
     case type.SURVEY_BUILDER_DELETE_CHOICE:
-        return update(state, { form: { sections: { [action.sectionIndex]:
-        { questions: { [action.questionIndex]: { choices: { $splice:
-            [[action.choiceIndex, 1]] } } } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+        {
+            questions: {
+                [action.questionIndex]: {
+                    choices: {
+                        $splice:
+            [[action.choiceIndex, 1]],
+                    },
+                },
+            },
+        },
+                },
+            },
+        });
     case type.SURVEY_BUILDER_UPSERT_SCALE: {
-        return update(state, { form: { sections: { [action.sectionIndex]:
-        { questions: { [action.questionIndex]: { scaleLimits: { [action.isMax ? 'max' : 'min']: {
-            $set: action.value } },
-            $unset: ['id'] } } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+        {
+            questions: {
+                [action.questionIndex]: {
+                    scaleLimits: {
+                        [action.isMax ? 'max' : 'min']: { $set: action.value },
+                    },
+                    $unset: ['id'],
+                },
+            },
+        },
+                },
+            },
+        });
     }
     case type.SURVEY_BUILDER_DELETE_QUESTION:
-        return update(state, { form: { sections: { [action.sectionIndex]:
-            { questions: { $splice: [[action.questionIndex, 1]] } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+            { questions: { $splice: [[action.questionIndex, 1]] } },
+                },
+            },
+        });
     case type.SURVEY_BUILDER_MOVE_QUESTION: {
         if (action.questionIndex === 0 && action.move < 0) {
             toast(action.errorMessages.ALREADY_TOP);
             return state;
         }
-        if ((action.questionIndex + action.move) ===
-            state.form.sections[action.sectionIndex].questions.length) {
+        if ((action.questionIndex + action.move)
+            === state.form.sections[action.sectionIndex].questions.length) {
             toast(action.errorMessages.ALREADY_BOTTOM);
             return state;
         }
@@ -124,17 +249,48 @@ export default (state = initialState, action) => {
         const tempQuestion = tempArray[action.questionIndex + action.move];
         tempArray[action.questionIndex + action.move] = tempArray[action.questionIndex];
         tempArray[action.questionIndex] = tempQuestion;
-        return update(state, { form: { sections: { [action.sectionIndex]:
-            { questions: { $set: tempArray } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+            { questions: { $set: tempArray } },
+                },
+            },
+        });
     }
     case type.SURVEY_BUILDER_UPSERT_WEIGHT:
-        return update(state, { form: { sections: { [action.sectionIndex]:
-        { questions: { [action.questionIndex]: { choices: { [action.choiceIndex]: {
-            weight: { $set: action.value } } } } } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+        {
+            questions: {
+                [action.questionIndex]: {
+                    choices: {
+                        [action.choiceIndex]: { weight: { $set: action.value } },
+                    },
+                },
+            },
+        },
+                },
+            },
+        });
     case type.SURVEY_BUILDER_RESET_META:
-        return update(state, { form: { sections: { [action.sectionIndex]:
-        { questions: { [action.questionIndex]: { meta:
-            { $unset: [action.field] } } } } } } });
+        return update(state, {
+            form: {
+                sections: {
+                    [action.sectionIndex]:
+        {
+            questions: {
+                [action.questionIndex]: {
+                    meta:
+            { $unset: [action.field] },
+                },
+            },
+        },
+                },
+            },
+        });
     default:
         return state;
     }

--- a/src/views/TaskReview/actions.js
+++ b/src/views/TaskReview/actions.js
@@ -36,19 +36,19 @@ export function upsertAnswer(assessmentId, questionId, answer, meta, errorMessag
 export function getDiscussions(taskId, errorMessages) { // errorMessages
     return (dispatch) => {
         apiService.discussions.getDiscussions(taskId)
-        .then(discussResp => dispatch(_getDiscussionsSuccess(discussResp)))
-        .catch(() => dispatch(_reportDiscussError(errorMessages.FETCH_DISCUSS)));
+            .then(discussResp => dispatch(_getDiscussionsSuccess(discussResp)))
+            .catch(() => dispatch(_reportDiscussError(errorMessages.FETCH_DISCUSS)));
     };
 }
 
 export function postDiscussion(requestBody, errorMessages) {
     return (dispatch) => {
         apiService.discussions.postDiscussion(requestBody)
-        .then((discussResp) => {
-            dispatch(_postDiscussionSuccess(discussResp));
-            dispatch(getDiscussions(requestBody.taskId, errorMessages));
-        })
-        .catch(() => dispatch(_reportDiscussError(errorMessages.FETCH_DISCUSS)));
+            .then((discussResp) => {
+                dispatch(_postDiscussionSuccess(discussResp));
+                dispatch(getDiscussions(requestBody.taskId, errorMessages));
+            })
+            .catch(() => dispatch(_reportDiscussError(errorMessages.FETCH_DISCUSS)));
     };
 }
 

--- a/src/views/TaskReview/components/FlagSidebar/FlagCommentary.js
+++ b/src/views/TaskReview/components/FlagSidebar/FlagCommentary.js
@@ -9,27 +9,27 @@ class FlagCommentary extends Component {
     render() {
         return (
             <div className='flag-commentary'>
-                {this.props.activeIndex >= 0 &&
-                    this.props.ui.flags[this.props.activeIndex].discussion.map((reply, index) => {
+                {this.props.activeIndex >= 0
+                    && this.props.ui.flags[this.props.activeIndex].discussion.map((reply, index) => {
                         return (
-                    <div className={`flag-commentary__frame${this.props.completed ? ' flag-commentary__frame--readonly' : ''}`}
-                        key={`flag-comment${index}`}>
-                        <div className='flag-commentary__timestamp'>
-                            {Time.renderFlagTimestamp(reply.created, this.props.vocab)}
-                        </div>
-                        <div className='flag-commentary__comment'>
-                            {reply.entry}
-                        </div>
-                        <div className='flag-commentary__signature'>
-                            –{renderName(this.props.profile.id === reply.userFromId ?
-                                this.props.profile :
-                                find(this.props.users, user => user.id === reply.userFromId))}
-                        </div>
-                    </div>
+                            <div className={`flag-commentary__frame${this.props.completed ? ' flag-commentary__frame--readonly' : ''}`}
+                                key={`flag-comment${index}`}>
+                                <div className='flag-commentary__timestamp'>
+                                    {Time.renderFlagTimestamp(reply.created, this.props.vocab)}
+                                </div>
+                                <div className='flag-commentary__comment'>
+                                    {reply.entry}
+                                </div>
+                                <div className='flag-commentary__signature'>
+                            –{renderName(this.props.profile.id === reply.userFromId
+                                        ? this.props.profile
+                                        : find(this.props.users, user => user.id === reply.userFromId))}
+                                </div>
+                            </div>
                         );
                     })}
-                {this.props.activeIndex < 0 &&
-                    <div className={`flag-commentary__frame${this.props.completed ? ' flag-commentary__frame--readonly' : ''}`}>
+                {this.props.activeIndex < 0
+                    && <div className={`flag-commentary__frame${this.props.completed ? ' flag-commentary__frame--readonly' : ''}`}>
                         {this.props.vocab.PROJECT.NO_COMMENTS}
                     </div>
                 }

--- a/src/views/TaskReview/components/FlagSidebar/FlagControlsForm.js
+++ b/src/views/TaskReview/components/FlagSidebar/FlagControlsForm.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Field, form, reduxForm, reset } from 'redux-form';
+import {
+    Field, form, reduxForm, reset,
+} from 'redux-form';
 import { toast } from 'react-toastify';
 
 import FlagUserSelect from './FlagUserSelect';
@@ -77,8 +79,8 @@ export default reduxForm({
                 values,
                 ownProps.vocab.ERROR,
             );
-            toast(values.isResolve ? ownProps.vocab.SURVEY.MARK_SENT :
-                ownProps.vocab.SURVEY.FLAG_SENT);
+            toast(values.isResolve ? ownProps.vocab.SURVEY.MARK_SENT
+                : ownProps.vocab.SURVEY.FLAG_SENT);
         }
     },
     onSubmitSuccess: (result, dispatch) => dispatch(reset(FORM_NAME)),

--- a/src/views/TaskReview/components/FlagSidebar/FlagQuestionList.js
+++ b/src/views/TaskReview/components/FlagSidebar/FlagQuestionList.js
@@ -23,18 +23,16 @@ class FlagQuestionList extends Component {
             <div className='flag-question-list'>
                 {this.props.displaySurvey.map((question, index) => {
                     let modifier = '';
-                    if (question.id === this.props.ui.flagSidebar.activeId ||
-                        (this.props.ui.flagSidebar.activeId === -1 && index === 0)) {
+                    if (question.id === this.props.ui.flagSidebar.activeId
+                        || (this.props.ui.flagSidebar.activeId === -1 && index === 0)) {
                         modifier = '--selected';
-                    } else if (some(this.props.ui.flags, flag =>
-                        parseInt(flag.questionId, 10) === question.id)) {
+                    } else if (some(this.props.ui.flags, flag => parseInt(flag.questionId, 10) === question.id)) {
                         modifier = '--inactive';
                     }
                     return (
                         <div key={`listitem${question}${index}`}
                             className={`flag-question-list__item flag-question-list__item${modifier}`}
-                            onClick={() =>
-                                this.onChangeQuestion(question.id, index)}>
+                            onClick={() => this.onChangeQuestion(question.id, index)}>
                             {this.props.vocab.PROJECT.QUESTION_ + (index + this.props.offset + 1) }
                         </div>
                     );

--- a/src/views/TaskReview/components/FlagSidebar/FlagUserSelect.js
+++ b/src/views/TaskReview/components/FlagSidebar/FlagUserSelect.js
@@ -7,8 +7,7 @@ class FlagUserSelect extends Component {
     render() {
         return (
             <Select
-                value={find(this.props.userOptions, option =>
-                    option.value === this.props.input.value) || this.props.userOptions[0]}
+                value={find(this.props.userOptions, option => option.value === this.props.input.value) || this.props.userOptions[0]}
                 onChange={(event) => { this.props.input.onChange(event.value); }}
                 clearable={false}
                 disabled={this.props.disabled}

--- a/src/views/TaskReview/components/FlagSidebar/index.js
+++ b/src/views/TaskReview/components/FlagSidebar/index.js
@@ -1,7 +1,9 @@
 import React, { Component } from 'react';
 import Box from 'grommet/components/Box';
 import scroller from 'react-scroll/modules/mixins/scroller';
-import { find, findIndex, get, some } from 'lodash';
+import {
+    find, findIndex, get, some,
+} from 'lodash';
 
 import { renderName } from '../../../../utils/User';
 import FlagHeader from './FlagHeader';
@@ -20,15 +22,15 @@ class FlagSidebar extends Component {
     }
 
     render() {
-        const userOptions = this.props.projectUsers ?
-            this.props.projectUsers.filter(projUser => projUser !== this.props.profile.id)
-            .map((projUserId) => {
-                const current = find(this.props.users, user => user.id === projUserId);
-                return {
-                    label: renderName(current),
-                    value: current.id,
-                };
-            }) : [];
+        const userOptions = this.props.projectUsers
+            ? this.props.projectUsers.filter(projUser => projUser !== this.props.profile.id)
+                .map((projUserId) => {
+                    const current = find(this.props.users, user => user.id === projUserId);
+                    return {
+                        label: renderName(current),
+                        value: current.id,
+                    };
+                }) : [];
         const initialValues = {
             questionId: this.props.ui.flagSidebar.activeId,
             taskId: this.props.task.id,
@@ -36,12 +38,10 @@ class FlagSidebar extends Component {
             userId: userOptions[0] === undefined ? null : userOptions[0].value,
         };
         const completed = get(this.props, 'task.status') === 'completed';
-        const activeIndex = findIndex(this.props.ui.flags, flag =>
-            parseInt(flag.questionId, 10) === this.props.ui.flagSidebar.activeId);
-        const formDisabled = !(this.props.taskedUser.id === this.props.profile.id ||
-            some(get(this.props.ui.flags[activeIndex], 'discussion'), chat =>
-            (chat.userId === this.props.profile.id ||
-            chat.userFromId === this.props.profile.id) && !chat.isResolve));
+        const activeIndex = findIndex(this.props.ui.flags, flag => parseInt(flag.questionId, 10) === this.props.ui.flagSidebar.activeId);
+        const formDisabled = !(this.props.taskedUser.id === this.props.profile.id
+            || some(get(this.props.ui.flags[activeIndex], 'discussion'), chat => (chat.userId === this.props.profile.id
+            || chat.userFromId === this.props.profile.id) && !chat.isResolve));
 
         return (
             <Box className='flag-sidebar'>
@@ -57,8 +57,8 @@ class FlagSidebar extends Component {
                             vocab={this.props.vocab}
                             activeIndex={activeIndex}
                             completed={completed} />
-                        {!completed &&
-                            <FlagControlsForm
+                        {!completed
+                            && <FlagControlsForm
                                 {...this.props}
                                 disabled={formDisabled}
                                 userOptions={userOptions}

--- a/src/views/TaskReview/components/QuestionContainer.js
+++ b/src/views/TaskReview/components/QuestionContainer.js
@@ -12,6 +12,7 @@ class QuestionContainer extends Component {
         this.changeQuestionsDisplay = this.changeQuestionsDisplay.bind(this);
         this.stopDetails = this.stopDetails.bind(this);
     }
+
     changeQuestionsDisplay() {
         let newShowQuestions;
         if (this.props.ui.showQuestions.includes(this.props.questionIndex)) {
@@ -23,44 +24,45 @@ class QuestionContainer extends Component {
         }
         this.props.actions.updateQuestionDisplay(newShowQuestions);
     }
+
     stopDetails(e) {
         e.stopPropagation();
     }
+
     render() {
         return (
             <details className='question-container'
                 onClick={this.changeQuestionsDisplay}
                 open={this.props.ui.showQuestions.includes(this.props.questionIndex)}>
-                  <summary className='question-container__summary'>
-                      {`${this.props.vocab.PROJECT.QUESTION_ + (this.props.questionIndex + this.props.offset + 1)}: ${
-                      this.props.question.text}${this.props.question.required ? ' *' : ''}`}
-                  </summary>
-                  <div onClick={this.stopDetails}>
-                      <Questions className='question-container__questions'
-                          {...this.props.question}
-                          assessmentId={this.props.task.assessmentId}
-                          answers={this.props.answers}
-                          fileEntryMode={!this.props.stage.discussionParticipation}
-                          displayMode={this.props.taskDisabled || this.props.stage.blindReview
+                <summary className='question-container__summary'>
+                    {`${this.props.vocab.PROJECT.QUESTION_ + (this.props.questionIndex + this.props.offset + 1)}: ${
+                        this.props.question.text}${this.props.question.required ? ' *' : ''}`}
+                </summary>
+                <div onClick={this.stopDetails}>
+                    <Questions className='question-container__questions'
+                        {...this.props.question}
+                        assessmentId={this.props.task.assessmentId}
+                        answers={this.props.answers}
+                        fileEntryMode={!this.props.stage.discussionParticipation}
+                        displayMode={this.props.taskDisabled || this.props.stage.blindReview
                               || this.props.stage.discussionParticipation}
-                          actions={this.props.actions}
-                          vocab={this.props.vocab} />
-                      {this.props.showCommentForm &&
-                          <ReviewPane
+                        actions={this.props.actions}
+                        vocab={this.props.vocab} />
+                    {this.props.showCommentForm
+                          && <ReviewPane
                               users={this.props.users}
                               profile={this.props.profile}
                               questionIndex={this.props.questionIndex + this.props.offset}
                               question={this.props.question}
-                              answer={find(this.props.answers, answer =>
-                                  answer.questionId === this.props.question.id) || {}}
+                              answer={find(this.props.answers, answer => answer.questionId === this.props.question.id) || {}}
                               assessmentId={this.props.task.assessmentId}
                               answers={this.props.answers}
                               entryMode={this.props.stage.discussionParticipation}
                               displayMode={this.props.taskDisabled || this.props.stage.blindReview
                                   || this.props.stage.allowEdit}
                               vocab={this.props.vocab } />
-                      }
-                  </div>
+                    }
+                </div>
             </details>
         );
     }

--- a/src/views/TaskReview/components/Questions/Bullet.js
+++ b/src/views/TaskReview/components/Questions/Bullet.js
@@ -13,29 +13,27 @@ class Bullet extends Component {
         }
         return (
             <div className='bullet'>
-                {currentAnswer.map((answer, index) =>
-                    <input className={`bullet__field bullet__field${this.props.displayMode ? '--disabled' : ''}`}
-                        key={`bullet-${this.props.id}-${index}`}
-                        placeholder={this.props.vocab.PROJECT.ENTER_ANSWER}
-                        type='text'
-                        disabled={this.props.displayMode}
-                        value={currentAnswer[index]}
-                        onChange={(event) => {
-                            currentAnswer[index] = event.target.value;
-                            if (index !== currentAnswer.length - 1) {
-                                currentAnswer.splice(currentAnswer.length - 1, 1);
-                            }
-                            if (event.target.value.match(/^\s*$/)) {
-                                currentAnswer.splice(index, 1);
-                            }
-                            this.props.holdAnswer(this.props.id,
-                                { textValue: currentAnswer.join('‣') });
-                        }}
-                        onBlur={() => {
+                {currentAnswer.map((answer, index) => <input className={`bullet__field bullet__field${this.props.displayMode ? '--disabled' : ''}`}
+                    key={`bullet-${this.props.id}-${index}`}
+                    placeholder={this.props.vocab.PROJECT.ENTER_ANSWER}
+                    type='text'
+                    disabled={this.props.displayMode}
+                    value={currentAnswer[index]}
+                    onChange={(event) => {
+                        currentAnswer[index] = event.target.value;
+                        if (index !== currentAnswer.length - 1) {
                             currentAnswer.splice(currentAnswer.length - 1, 1);
-                            this.props.upsertAnswer({ textValue: currentAnswer.join('‣') });
-                        }} />,
-            )}
+                        }
+                        if (event.target.value.match(/^\s*$/)) {
+                            currentAnswer.splice(index, 1);
+                        }
+                        this.props.holdAnswer(this.props.id,
+                            { textValue: currentAnswer.join('‣') });
+                    }}
+                    onBlur={() => {
+                        currentAnswer.splice(currentAnswer.length - 1, 1);
+                        this.props.upsertAnswer({ textValue: currentAnswer.join('‣') });
+                    }} />)}
             </div>
         );
     }

--- a/src/views/TaskReview/components/Questions/Choice.js
+++ b/src/views/TaskReview/components/Questions/Choice.js
@@ -6,28 +6,30 @@ class Choice extends Component {
     render() {
         return (
             <div className='choice'>
-                {this.props.choices.map(choice =>
-                    <div className='choice__radio'
-                        key={`key-choice-${choice.id}`}>
-                        <input className={`choice__field choice__field${this.props.displayMode ? '--disabled' : ''}`}
-                            type='radio'
-                            name={`choice${this.props.id}`}
-                            value={choice.id}
-                            defaultChecked={this.props.answer ?
-                                choice.id === this.props.answer.choice : false }
-                            onChange={(event) => {
-                                const entry = (this.props.choicesId !== undefined ?
-                                { choices: unionBy([{ id: this.props.choicesId,
-                                    choice: parseInt(event.target.value, 10) }], this.props.answer, 'id') } :
-                                { choice: parseInt(event.target.value, 10) });
-                                this.props.upsertAnswer(entry);
-                            } }
-                            disabled={this.props.displayMode} />
-                        <span className='choice__field-label'>
-                            {` ${choice.text}`}
-                        </span>
-                    </div>,
-                )}
+                {this.props.choices.map(choice => <div className='choice__radio'
+                    key={`key-choice-${choice.id}`}>
+                    <input className={`choice__field choice__field${this.props.displayMode ? '--disabled' : ''}`}
+                        type='radio'
+                        name={`choice${this.props.id}`}
+                        value={choice.id}
+                        defaultChecked={this.props.answer
+                            ? choice.id === this.props.answer.choice : false }
+                        onChange={(event) => {
+                            const entry = (this.props.choicesId !== undefined
+                                ? {
+                                    choices: unionBy([{
+                                        id: this.props.choicesId,
+                                        choice: parseInt(event.target.value, 10),
+                                    }], this.props.answer, 'id'),
+                                }
+                                : { choice: parseInt(event.target.value, 10) });
+                            this.props.upsertAnswer(entry);
+                        } }
+                        disabled={this.props.displayMode} />
+                    <span className='choice__field-label'>
+                        {` ${choice.text}`}
+                    </span>
+                </div>)}
             </div>
         );
     }

--- a/src/views/TaskReview/components/Questions/Choices.js
+++ b/src/views/TaskReview/components/Questions/Choices.js
@@ -6,23 +6,24 @@ class Choices extends Component {
     render() {
         return (
             <div className='choices'>
-                {this.props.choices.map((choice, index) =>
-                    <div className='choices__row'
-                        key={`choices-${this.props.id}-${index}`}>
-                        <input className={`choices__field choices__field${this.props.displayMode ? '--disabled' : ''}`}
-                            type='checkbox'
-                            disabled={this.props.displayMode}
-                            defaultChecked={get(find(this.props.answer.choices, item =>
-                                item.id === choice.id), 'boolValue', false)}
-                            onClick={(event) => {
-                                this.props.upsertAnswer({ choices: unionBy([{ id: choice.id,
-                                    boolValue: event.target.checked }], this.props.answer.choices, 'id') });
-                            }} />
-                        <span className='choices__label'>
-                            {` ${choice.text}`}
-                        </span>
-                    </div>,
-                )}
+                {this.props.choices.map((choice, index) => <div className='choices__row'
+                    key={`choices-${this.props.id}-${index}`}>
+                    <input className={`choices__field choices__field${this.props.displayMode ? '--disabled' : ''}`}
+                        type='checkbox'
+                        disabled={this.props.displayMode}
+                        defaultChecked={get(find(this.props.answer.choices, item => item.id === choice.id), 'boolValue', false)}
+                        onClick={(event) => {
+                            this.props.upsertAnswer({
+                                choices: unionBy([{
+                                    id: choice.id,
+                                    boolValue: event.target.checked,
+                                }], this.props.answer.choices, 'id'),
+                            });
+                        }} />
+                    <span className='choices__label'>
+                        {` ${choice.text}`}
+                    </span>
+                </div>)}
             </div>
         );
     }

--- a/src/views/TaskReview/components/Questions/Date.js
+++ b/src/views/TaskReview/components/Questions/Date.js
@@ -11,21 +11,22 @@ class Date extends Component {
         return (
             <div className='date'>
                 {
-                    (this.props.displayMode &&
-                    (
-                        currentAnswer ?
-                        <div className='date__field'>
-                            {currentAnswer}
-                        </div> :
-                        this.props.vocab.SURVEY.NO_DATE_ENTERED
-                    )) ||
-                    <DateInput className='date__field'
+                    (this.props.displayMode
+                    && (
+                        currentAnswer
+                            ? <div className='date__field'>
+                                {currentAnswer}
+                            </div>
+                            : this.props.vocab.SURVEY.NO_DATE_ENTERED
+                    ))
+                    || <DateInput className='date__field'
                         value={currentAnswer}
                         inline={true}
                         onChange={(date) => {
                             if (Time.validateTime(date)) {
                                 this.props.upsertAnswer(
-                                    { dateValue: Time.renderForSurvey(date) });
+                                    { dateValue: Time.renderForSurvey(date) },
+                                );
                             }
                         }} />
                 }

--- a/src/views/TaskReview/components/Questions/Dropdown.js
+++ b/src/views/TaskReview/components/Questions/Dropdown.js
@@ -7,30 +7,29 @@ class Dropdown extends Component {
     render() {
         let currentValue = get(this.props, 'answer', undefined);
         if (currentValue) {
-            currentValue = this.props.choices.find(choice =>
-                choice.id === currentValue.choice).text;
+            currentValue = this.props.choices.find(choice => choice.id === currentValue.choice).text;
         }
         return (
             <div className='dropdown'>
                 {
-                    this.props.displayMode ?
-                    <select className='dropdown__field-disabled'
-                        value={currentValue}
-                        placeholder={this.props.vocab.PROJECT.SELECT_OPTION}
-                        disabled={true}>
-                        <option className='dropdown__option'
-                            label={currentValue} />
-                    </select> :
-                    <Select className='dropdown__field'
-                        value={currentValue}
-                        placeHolder={this.props.vocab.PROJECT.SELECT_OPTION}
-                        readOnly={this.props.displayMode}
-                        options={this.props.choices.map((entry) => {
-                            return { label: entry.text, value: entry.id };
-                        })}
-                        onChange={(event) => {
-                            this.props.upsertAnswer({ choice: event.option.value });
-                        }} />
+                    this.props.displayMode
+                        ? <select className='dropdown__field-disabled'
+                            value={currentValue}
+                            placeholder={this.props.vocab.PROJECT.SELECT_OPTION}
+                            disabled={true}>
+                            <option className='dropdown__option'
+                                label={currentValue} />
+                        </select>
+                        : <Select className='dropdown__field'
+                            value={currentValue}
+                            placeHolder={this.props.vocab.PROJECT.SELECT_OPTION}
+                            readOnly={this.props.displayMode}
+                            options={this.props.choices.map((entry) => {
+                                return { label: entry.text, value: entry.id };
+                            })}
+                            onChange={(event) => {
+                                this.props.upsertAnswer({ choice: event.option.value });
+                            }} />
                 }
             </div>
         );

--- a/src/views/TaskReview/components/Questions/Dropdown.js
+++ b/src/views/TaskReview/components/Questions/Dropdown.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
-import { Select } from 'grommet';
+import Select from 'grommet/components/Select';
 
 class Dropdown extends Component {
     render() {

--- a/src/views/TaskReview/components/Questions/FileForm.js
+++ b/src/views/TaskReview/components/Questions/FileForm.js
@@ -10,25 +10,25 @@ class FileForm extends Component {
     render() {
         return (
             <form className='file-form'
-                  onSubmit={this.props.handleSubmit}>
+                onSubmit={this.props.handleSubmit}>
                 {
-                    this.props.file === undefined &&
-                    <div className='file-form__add-form'>
+                    this.props.file === undefined
+                    && <div className='file-form__add-form'>
                         <Field name={'file'}
-                               className='file-form__file-input'
-                               disabled={this.props.disabled}
-                               component={ReduxFormFileInput}/>
+                            className='file-form__file-input'
+                            disabled={this.props.disabled}
+                            component={ReduxFormFileInput}/>
                     </div>
                 }
                 {
-                    this.props.file !== undefined &&
-                    <div className='file-form__remove-form'>
+                    this.props.file !== undefined
+                    && <div className='file-form__remove-form'>
                         <div className='file-form__current-file-name'>
                             <a href={this.props.file.url}> {this.props.file.filename} </a>
                         </div>
                         {
-                            !this.props.disabled &&
-                            <button className='file-form__submit file-form__submit--remove'>
+                            !this.props.disabled
+                            && <button className='file-form__submit file-form__submit--remove'>
                                 {this.props.vocab.SURVEY.REMOVE_FILE}
                             </button>
                         }
@@ -64,4 +64,3 @@ export default reduxForm({
         }
     },
 })(FileForm);
-

--- a/src/views/TaskReview/components/Questions/FilePane.js
+++ b/src/views/TaskReview/components/Questions/FilePane.js
@@ -5,8 +5,8 @@ class FilePane extends Component {
     render() {
         return (
             <div className='file-pane'>
-                {this.props.file === undefined &&
-                    <div className='file-pane__add-form'>
+                {this.props.file === undefined
+                    && <div className='file-pane__add-form'>
                         <input name={'file'}
                             className='file-pane__file-input'
                             disabled={this.props.disabled} />
@@ -16,14 +16,14 @@ class FilePane extends Component {
                             {this.props.vocab.SURVEY.ADD_FILE}
                         </button>
                     </div>}
-                {this.props.file !== undefined &&
-                    <div className='file-pane__remove-form'>
+                {this.props.file !== undefined
+                    && <div className='file-pane__remove-form'>
                         <div className='file-pane__current-file-name'>
                             {this.props.file.filename}
                         </div>
                         {
-                            !this.props.disabled &&
-                            <button className='file-pane__submit file-pane__submit--remove'>
+                            !this.props.disabled
+                            && <button className='file-pane__submit file-pane__submit--remove'>
                                 {this.props.vocab.SURVEY.REMOVE_FILE}
                             </button>
                         }

--- a/src/views/TaskReview/components/Questions/Text.js
+++ b/src/views/TaskReview/components/Questions/Text.js
@@ -11,10 +11,14 @@ class Text extends Component {
                     disabled={this.props.displayMode}
                     defaultValue={get(this.props, 'answer.textValue', '')}
                     onBlur={(event) => {
-                        const entry = (this.props.choicesId !== undefined ?
-                        { choices: unionBy([{ id: this.props.choicesId,
-                            textValue: event.target.value }], this.props.answer, 'id') } :
-                        { textValue: event.target.value });
+                        const entry = (this.props.choicesId !== undefined
+                            ? {
+                                choices: unionBy([{
+                                    id: this.props.choicesId,
+                                    textValue: event.target.value,
+                                }], this.props.answer, 'id'),
+                            }
+                            : { textValue: event.target.value });
                         this.props.upsertAnswer(entry);
                     }}
                 />

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { find, get, has, merge, omit } from 'lodash';
+import {
+    find, get, has, merge, omit,
+} from 'lodash';
 import DateTime from 'grommet/components/DateTime';
 
 import FileForm from './FileForm';
@@ -24,7 +26,8 @@ class Questions extends Component {
             this.props.id,
             newAnswer,
             get(value, 'meta', undefined),
-            this.props.vocab.ERROR);
+            this.props.vocab.ERROR,
+        );
         switch (this.props.type) {
         case 'bullet':
             QuestionType = (<Bullet
@@ -40,12 +43,12 @@ class Questions extends Component {
                 answer={value ? value.answer : undefined} />);
             break;
         case 'choice':
-            QuestionType = (get(this.props, 'meta.subType') === 'dropdown') ?
-                (<Dropdown
+            QuestionType = (get(this.props, 'meta.subType') === 'dropdown')
+                ? (<Dropdown
                     {...this.props}
                     upsertAnswer = {upsertAnswer}
-                    answer={value ? value.answer : undefined} />) :
-                (<Choice
+                    answer={value ? value.answer : undefined} />)
+                : (<Choice
                     {...this.props}
                     upsertAnswer = {upsertAnswer}
                     answer={value ? value.answer : undefined} />);
@@ -81,40 +84,40 @@ class Questions extends Component {
                 <div className='questions__type'>
                     {QuestionType}
                 </div>
-                {has(this.props, 'meta.file') &&
-                    <div className='questions__option-panel'>
-                    {this.props.fileEntryMode ?
-                        <FileForm
-                            form={`file-form-${this.props.id}`}
-                            vocab={this.props.vocab}
-                            disabled={noValue || this.props.displayMode}
-                            file={get(value, 'meta.file')}
-                            onFileUploaded={(file) => {
-                                this.props.actions.upsertAnswer(
-                                    this.props.assessmentId,
-                                    this.props.id,
-                                    value.answer,
-                                    merge(value.meta, { file }),
-                                    this.props.vocab.ERROR,
-                                );
-                            }}
-                            onFileRemoved={() => {
-                                this.props.actions.upsertAnswer(
-                                    this.props.assessmentId,
-                                    this.props.id,
-                                    value.answer,
-                                    omit(value.meta, 'file'),
-                                    this.props.vocab.ERROR,
-                                );
-                            }}/> :
-                        <FilePane
-                            vocab={this.props.vocab}
-                            disabled={noValue || this.props.displayMode}
-                            file={get(value, 'meta.file')} />}
+                {has(this.props, 'meta.file')
+                    && <div className='questions__option-panel'>
+                        {this.props.fileEntryMode
+                            ? <FileForm
+                                form={`file-form-${this.props.id}`}
+                                vocab={this.props.vocab}
+                                disabled={noValue || this.props.displayMode}
+                                file={get(value, 'meta.file')}
+                                onFileUploaded={(file) => {
+                                    this.props.actions.upsertAnswer(
+                                        this.props.assessmentId,
+                                        this.props.id,
+                                        value.answer,
+                                        merge(value.meta, { file }),
+                                        this.props.vocab.ERROR,
+                                    );
+                                }}
+                                onFileRemoved={() => {
+                                    this.props.actions.upsertAnswer(
+                                        this.props.assessmentId,
+                                        this.props.id,
+                                        value.answer,
+                                        omit(value.meta, 'file'),
+                                        this.props.vocab.ERROR,
+                                    );
+                                }}/>
+                            : <FilePane
+                                vocab={this.props.vocab}
+                                disabled={noValue || this.props.displayMode}
+                                file={get(value, 'meta.file')} />}
                     </div>
                 }
-                {has(this.props, 'meta.publication') &&
-                    <div className='questions__option-panel'>
+                {has(this.props, 'meta.publication')
+                    && <div className='questions__option-panel'>
                         <div className='questions__link-fields-top'>
                             <span className='questions__add-link'>
                                 {this.props.vocab.SURVEY.ADD_LINK}
@@ -129,7 +132,8 @@ class Questions extends Component {
                                     value.answer,
                                     merge(value.meta,
                                         { publication: { link: event.target.value } }),
-                                    this.props.vocab.ERROR)} />
+                                    this.props.vocab.ERROR,
+                                )} />
                         </div>
                         <div className='questions__link-fields-bottom'>
                             <input className='questions__title-input'
@@ -143,7 +147,8 @@ class Questions extends Component {
                                     value.answer,
                                     merge(value.meta,
                                         { publication: { title: event.target.value } }),
-                                    this.props.vocab.ERROR)} />
+                                    this.props.vocab.ERROR,
+                                )} />
                             <input className='questions__author-input'
                                 type='text'
                                 disabled={noValue || this.props.displayMode}
@@ -155,26 +160,28 @@ class Questions extends Component {
                                     value.answer,
                                     merge(value.meta,
                                         { publication: { author: event.target.value } }),
-                                    this.props.vocab.ERROR)} />
-                                { (noValue || this.props.displayMode) ?
-                                    <input className='questions__date-disabled'
-                                        value={get(value, 'meta.publication.date', 'MM/DD/YYYY')}
-                                        disabled={true} /> :
-                                    <DateTime className='questions__date-input'
-                                        value={get(value, 'meta.publication.date', '')}
-                                        format='MM/DD/YYYY'
-                                        onChange={(event) => {
-                                            if (Time.validateTime(event)) {
-                                                this.props.actions.upsertAnswer(
-                                                    this.props.assessmentId,
-                                                    this.props.id,
-                                                    value.answer,
-                                                    merge(value.meta,
-                                                        { publication: { date: event } }),
-                                                    this.props.vocab.ERROR);
-                                            }
-                                        }} />
-                                }
+                                    this.props.vocab.ERROR,
+                                )} />
+                            { (noValue || this.props.displayMode)
+                                ? <input className='questions__date-disabled'
+                                    value={get(value, 'meta.publication.date', 'MM/DD/YYYY')}
+                                    disabled={true} />
+                                : <DateTime className='questions__date-input'
+                                    value={get(value, 'meta.publication.date', '')}
+                                    format='MM/DD/YYYY'
+                                    onChange={(event) => {
+                                        if (Time.validateTime(event)) {
+                                            this.props.actions.upsertAnswer(
+                                                this.props.assessmentId,
+                                                this.props.id,
+                                                value.answer,
+                                                merge(value.meta,
+                                                    { publication: { date: event } }),
+                                                this.props.vocab.ERROR,
+                                            );
+                                        }
+                                    }} />
+                            }
                         </div>
                     </div>
                 }

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { find, get, has, merge, omit } from 'lodash';
-import { DateTime } from 'grommet';
+import DateTime from 'grommet/components/DateTime';
 
 import FileForm from './FileForm';
 import FilePane from './FilePane';

--- a/src/views/TaskReview/components/ReviewPane.js
+++ b/src/views/TaskReview/components/ReviewPane.js
@@ -9,26 +9,24 @@ class ReviewPane extends Component {
     render() {
         return (
             <div className='review-pane'>
-                {has(this.props, 'answer.commentHistory') &&
-                    <div className='review-pane__display'>
-                        {this.props.answer.commentHistory.map((comment, index) =>
-                            <div className='review-pane__comment'
-                                key={`review-pane-comment${index}`}>
-                                <div className='review-pane__comment-reason'>
-                                    {this.props.vocab.COMMON[comment.reason.toUpperCase()]}
-                                </div>
-                                <div className='review-pane__comment-text'>
-                                    {comment.text}
-                                </div>
-                                <div className='review-pane__comment-signature'>
+                {has(this.props, 'answer.commentHistory')
+                    && <div className='review-pane__display'>
+                        {this.props.answer.commentHistory.map((comment, index) => <div className='review-pane__comment'
+                            key={`review-pane-comment${index}`}>
+                            <div className='review-pane__comment-reason'>
+                                {this.props.vocab.COMMON[comment.reason.toUpperCase()]}
+                            </div>
+                            <div className='review-pane__comment-text'>
+                                {comment.text}
+                            </div>
+                            <div className='review-pane__comment-signature'>
                                     –{renderName(find(this.props.users,
-                                        user => user.authId === comment.userId))}
-                                </div>
-                            </div>,
-                        )}
+                                    user => user.authId === comment.userId))}
+                            </div>
+                        </div>)}
                     </div> }
-                {this.props.entryMode &&
-                    <div className='review-pane__control-container'>
+                {this.props.entryMode
+                    && <div className='review-pane__control-container'>
                         <div className='review-pane__controls'>
                             <label className='review-pane__radio-controls'>
                                 <Field

--- a/src/views/TaskReview/components/SurveyForm.js
+++ b/src/views/TaskReview/components/SurveyForm.js
@@ -36,7 +36,7 @@ export default reduxForm({
         const answers = compact(values.answers.map((answer, index) => {
             if (get(answer, 'comment.reason') === undefined) {
                 return null;
-            } else if (answer.comment.reason === 'disagree' && !answer.comment.text) {
+            } if (answer.comment.reason === 'disagree' && !answer.comment.text) {
                 disagreeCheck.push(index + 1);
                 return null;
             }
@@ -47,8 +47,7 @@ export default reduxForm({
             return Promise.reject();
         }
         return ownProps.actions.postReview(values.assessmentId,
-                answers,
-                ownProps.vocab.ERROR,
-            ).then(toast(ownProps.vocab.PROJECT.PROGRESS_SAVED));
+            answers,
+            ownProps.vocab.ERROR).then(toast(ownProps.vocab.PROJECT.PROGRESS_SAVED));
     },
 })(SurveyForm);

--- a/src/views/TaskReview/components/SurveyPane.js
+++ b/src/views/TaskReview/components/SurveyPane.js
@@ -13,6 +13,7 @@ class SurveyPane extends Component {
         this.onCompleteTask = this.onCompleteTask.bind(this);
         this.storeFormRef = this.storeFormRef.bind(this);
     }
+
     onCompleteTask() {
         const preventComplete = !this.props.reqCheck || this.props.flagCount !== 0;
         if (!preventComplete) {
@@ -20,33 +21,35 @@ class SurveyPane extends Component {
                 this.props.productId,
                 this.props.task.uoaId,
                 this.props.vocab.ERROR,
-                ).then(() => this.props.actions.completeAssessment(
-                    this.props.task.assessmentId,
-                    this.props.vocab.ERROR,
-                    )).then(() => toast(this.props.vocab.PROJECT.TASK_COMPLETED));
+            ).then(() => this.props.actions.completeAssessment(
+                this.props.task.assessmentId,
+                this.props.vocab.ERROR,
+            )).then(() => toast(this.props.vocab.PROJECT.TASK_COMPLETED));
         } else if (this.props.flagCount > 0) {
             toast(this.props.vocab.ERROR.FLAGGED_QUESTIONS);
         } else {
             toast(this.props.vocab.ERROR.REQUIRE_ANSWERS);
         }
     }
+
     storeFormRef(formRef) {
         this.formRef = formRef;
     }
+
     render() {
         const preventComplete = !this.props.reqCheck || this.props.flagCount !== 0;
         const initialValues = {
             answers: this.props.answers,
             assessmentId: this.props.task.assessmentId,
         };
-        const showCommentForm = this.props.stage.discussionParticipation ||
-            this.props.stage.blindReview || this.props.stage.allowEdit;
+        const showCommentForm = this.props.stage.discussionParticipation
+            || this.props.stage.blindReview || this.props.stage.allowEdit;
 
-        const handleCompleteTaskClick = this.props.stage.discussionParticipation ?
-            () => this.formRef.submit()
-            .then(this.onCompleteTask)
-            .catch(() => null) :
-            this.onCompleteTask;
+        const handleCompleteTaskClick = this.props.stage.discussionParticipation
+            ? () => this.formRef.submit()
+                .then(this.onCompleteTask)
+                .catch(() => null)
+            : this.onCompleteTask;
         return (
             <div className='survey-pane'>
                 <div className='survey-pane__controls'>
@@ -59,33 +62,34 @@ class SurveyPane extends Component {
                     <div className='survey-pane__accordion-buttons'>
                         <button className='survey-pane__button-expand'
                             onClick={() => this.props.actions.updateQuestionDisplay(
-                                this.props.survey.map((key, index) => index))}>
-                                {this.props.vocab.PROJECT.EXPAND_ALL}</button>
+                                this.props.survey.map((key, index) => index),
+                            )}>
+                            {this.props.vocab.PROJECT.EXPAND_ALL}</button>
                         <button className='survey-pane__button-collapse'
                             onClick={() => this.props.actions.updateQuestionDisplay([])}>
                             {this.props.vocab.PROJECT.COLLAPSE_ALL}</button>
                     </div>
                 </div>
                 {!(this.props.stage.blindReview || this.props.stage.allowEdit
-                    || this.props.stage.discussionParticipation) &&
-                    <div className='survey-pane__instructions'>
+                    || this.props.stage.discussionParticipation)
+                    && <div className='survey-pane__instructions'>
                         <div className='survey-pane__instructions-header'>
                             {this.props.vocab.PROJECT.INSTRUCTIONS}
                         </div>
                         <span className='survey-pane__instructions-explained'>
-                            {this.props.instructions ||
-                                this.props.vocab.PROJECT.INSTRUCTIONS_EXPLAINED}
+                            {this.props.instructions
+                                || this.props.vocab.PROJECT.INSTRUCTIONS_EXPLAINED}
                         </span>
                         <span className='survey-pane__instructions-explained'>
-                            {this.props.vocab.PROJECT.INSTRUCTIONS_EXPLAINED_2 +
-                                (this.props.ui.lastSave === null ?
-                                    this.props.vocab.PROJECT.NOT_SAVED :
-                                    Time.renderAutosave(this.props.ui.lastSave))}
+                            {this.props.vocab.PROJECT.INSTRUCTIONS_EXPLAINED_2
+                                + (this.props.ui.lastSave === null
+                                    ? this.props.vocab.PROJECT.NOT_SAVED
+                                    : Time.renderAutosave(this.props.ui.lastSave))}
                         </span>
                     </div>
                 }
-                {(this.props.stage.id === undefined || this.props.stage.discussionParticipation) ?
-                    <SurveyForm
+                {(this.props.stage.id === undefined || this.props.stage.discussionParticipation)
+                    ? <SurveyForm
                         ref={this.storeFormRef}
                         {...this.props}
                         initialValues={initialValues}>
@@ -94,8 +98,8 @@ class SurveyPane extends Component {
                             onCompleteTask={handleCompleteTaskClick}
                             preventComplete={preventComplete}
                             showCommentForm={showCommentForm} />
-                    </SurveyForm> :
-                    <SurveyPresentation
+                    </SurveyForm>
+                    : <SurveyPresentation
                         {...this.props}
                         onCompleteTask={handleCompleteTaskClick}
                         preventComplete={preventComplete}

--- a/src/views/TaskReview/components/SurveyPresentation.js
+++ b/src/views/TaskReview/components/SurveyPresentation.js
@@ -12,8 +12,8 @@ class SurveyPresentation extends Component {
                     return (
                         <div className='survey-presentation__question'
                             key={`questionpanel${index}`}>
-                            {question.sectionName &&
-                              (<div className='survey-presentation__section-name'>
+                            {question.sectionName
+                              && (<div className='survey-presentation__section-name'>
                                   {question.sectionName}
                               </div>)}
                             <Element name={`question${index}`}>
@@ -24,16 +24,16 @@ class SurveyPresentation extends Component {
                             </Element>
                         </div>);
                 })}
-                {!this.props.taskDisabled &&
-                    <div className='survey-presentation__submit'>
+                {!this.props.taskDisabled
+                    && <div className='survey-presentation__submit'>
                         <div className='survey-presentation__submit-instructions'>
                             {this.props.vocab.SURVEY.SUBMIT_INSTRUCTIONS}
                             <br></br>
-                            {(this.props.stage.allowEdit ||
-                                this.props.stage.discussionParticipation) &&
-                                this.props.vocab.SURVEY.REVIEW_INSTRUCTIONS }
-                            {!this.props.stage.discussionParticipation &&
-                                <div className='survey-presentation__additional-instructions'>
+                            {(this.props.stage.allowEdit
+                                || this.props.stage.discussionParticipation)
+                                && this.props.vocab.SURVEY.REVIEW_INSTRUCTIONS }
+                            {!this.props.stage.discussionParticipation
+                                && <div className='survey-presentation__additional-instructions'>
                                     {this.props.vocab.SURVEY.SUBMIT_INSTRUCTIONS_2}
                                     <Link className='survey-presentation__link' to='/task'>
                                         {this.props.vocab.COMMON.MY_TASKS}
@@ -43,12 +43,12 @@ class SurveyPresentation extends Component {
                         </div>
                         <button className={`survey-presentation__submit-button
                             survey-presentation__submit-button${!this.props.preventComplete ? '' : '--disabled'}`}
-                            type='button'
-                            onClick={this.props.onCompleteTask}>
+                        type='button'
+                        onClick={this.props.onCompleteTask}>
                             {this.props.vocab.SURVEY.SUBMIT_TASK}
                         </button>
-                        {this.props.stage.discussionParticipation &&
-                            <button className='survey-presentation__submit-button'
+                        {this.props.stage.discussionParticipation
+                            && <button className='survey-presentation__submit-button'
                                 type='submit'>
                                 {this.props.vocab.SURVEY.SAVE_REVIEW}
                             </button>}

--- a/src/views/TaskReview/components/TaskDetails.js
+++ b/src/views/TaskReview/components/TaskDetails.js
@@ -47,22 +47,23 @@ class TaskDetails extends Component {
                         </div>
                     </div>
                     <div className='task-details__info-box'>
-                    <div className='task-details__info-box-label'>
-                        {this.props.vocab.PROJECT.TASK_DUE_DATE}
-                    </div>
-                    { this.props.profile.roleID === 2 ?
-                        <DateInput value={this.props.task.endDate}
-                            onChange={(event) => {
-                                this.props.actions.updateTask(
-                                    this.props.task.id,
-                                    this.props.task.userIds,
-                                    event,
-                                    this.props.vocab.ERROR);
-                            }} /> :
-                        <div className='task-details__info-box-title'>
-                            {Time.renderCommon(this.props.task.endDate)}
+                        <div className='task-details__info-box-label'>
+                            {this.props.vocab.PROJECT.TASK_DUE_DATE}
                         </div>
-                    }
+                        { this.props.profile.roleID === 2
+                            ? <DateInput value={this.props.task.endDate}
+                                onChange={(event) => {
+                                    this.props.actions.updateTask(
+                                        this.props.task.id,
+                                        this.props.task.userIds,
+                                        event,
+                                        this.props.vocab.ERROR,
+                                    );
+                                }} />
+                            : <div className='task-details__info-box-title'>
+                                {Time.renderCommon(this.props.task.endDate)}
+                            </div>
+                        }
                     </div>
                     <div className='task-details__info-box'>
                         <div className='task-details__info-box-label'>

--- a/src/views/TaskReview/components/index.js
+++ b/src/views/TaskReview/components/index.js
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
-import { compact, clone, every, find, flatten, get, has, map, sumBy } from 'lodash';
+import {
+    compact, clone, every, find, flatten, get, has, map, sumBy,
+} from 'lodash';
 import IonIcon from 'react-ionicons';
 
 import Time from '../../../utils/Time';
@@ -10,7 +12,9 @@ import FlagSidebar from './FlagSidebar';
 import TaskDetails from './TaskDetails';
 import SurveyPane from './SurveyPane';
 import { renderPermissions } from '../../../utils/Survey';
-import { setSurveySectionIndex, completeAssessment, postAnswer, postReview } from '../../../common/actions/surveyActions';
+import {
+    setSurveySectionIndex, completeAssessment, postAnswer, postReview,
+} from '../../../common/actions/surveyActions';
 import { getTaskById, moveTask, updateTask } from '../../../common/actions/taskActions';
 import * as actions from '../actions';
 
@@ -39,11 +43,11 @@ class TaskReview extends Component {
             })));
         }
         options.unshift({ value: -1, label: this.props.vocab.SURVEY.VIEW_ALL });
-        const displaySurvey = this.props.sectionIndex === -1 ?
-            flatSurvey : compact(get(this.props.survey, `sections[${this.props.sectionIndex}].questions`));
+        const displaySurvey = this.props.sectionIndex === -1
+            ? flatSurvey : compact(get(this.props.survey, `sections[${this.props.sectionIndex}].questions`));
         const taskDisabled = this.props.survey.status !== 'published' || !Time.isInPast(this.props.task.startDate)
-            || this.props.profile.id !== this.props.taskedUser.id || (this.props.task.status !== 'current' &&
-            !this.props.task.active);
+            || this.props.profile.id !== this.props.taskedUser.id || (this.props.task.status !== 'current'
+            && !this.props.task.active);
         const reqCheck = every(flatSurvey, (question) => {
             return get(question, 'required') === true ? has(find(this.props.ui.form.answers,
                 resp => resp.questionId === question.id), 'answer') : true;
@@ -101,11 +105,11 @@ class TaskReview extends Component {
                         vocab={this.props.vocab} />
                 </div>
                 <div className='task-review__flag-sidebar'>
-                <FlagSidebar
-                    {...this.props}
-                    offset={offset}
-                    flagCount={flagCount}
-                    displaySurvey={displaySurvey}/>
+                    <FlagSidebar
+                        {...this.props}
+                        offset={offset}
+                        flagCount={flagCount}
+                        displaySurvey={displaySurvey}/>
                 </div>
             </div>
         );
@@ -115,27 +119,28 @@ class TaskReview extends Component {
 const mapStateToProps = (state, ownProps) => {
     const taskId = parseInt(ownProps.params.taskId, 10);
     const projectId = parseInt(ownProps.params.projectId, 10);
-    const task = find(state.tasks.data, current => current.id === taskId) ||
-        { id: -1, title: '', endDate: '', userIds: [], stepId: -1, uoaId: -1 };
-    const project = state.projects.data.length !== 0 ?
-        find(state.projects.data, projElem => projElem.id === projectId) :
-        state.projects.empty;
+    const task = find(state.tasks.data, current => current.id === taskId)
+        || {
+            id: -1, title: '', endDate: '', userIds: [], stepId: -1, uoaId: -1,
+        };
+    const project = state.projects.data.length !== 0
+        ? find(state.projects.data, projElem => projElem.id === projectId)
+        : state.projects.empty;
     return {
         projectId,
         productId: project.productId,
-        taskedUser: find(state.user.users, user =>
-            user.id === task.userIds[0]) || { firstName: '', lastName: '' },
-        stage: (project.id > 0 && task.stepId > 0 && project.stages.length > 0) ?
-            find(project.stages, stage => stage.id === task.stepId) : { title: '' },
-        subject: (project.id > 0 && task.uoaId > 0) ?
-            find(project.subjects, subject => subject.id === task.uoaId) : { name: '' },
+        taskedUser: find(state.user.users, user => user.id === task.userIds[0]) || { firstName: '', lastName: '' },
+        stage: (project.id > 0 && task.stepId > 0 && project.stages.length > 0)
+            ? find(project.stages, stage => stage.id === task.stepId) : { title: '' },
+        subject: (project.id > 0 && task.uoaId > 0)
+            ? find(project.subjects, subject => subject.id === task.uoaId) : { name: '' },
         users: state.user.users,
         projectUsers: project.users,
         profile: state.user.profile,
         task,
-        survey: state.surveys.data[0].name ?
-            find(state.surveys.data, survey => survey.id === project.surveyId) :
-            state.surveys.data[0],
+        survey: state.surveys.data[0].name
+            ? find(state.surveys.data, survey => survey.id === project.surveyId)
+            : state.surveys.data[0],
         sectionIndex: state.surveys.ui.sectionIndex,
         ui: state.taskreview.ui,
         vocab: state.settings.language.vocabulary,
@@ -150,8 +155,9 @@ const mapDispatchToProps = dispatch => ({
         getTaskById,
         moveTask,
         postReview,
-        postAnswer }),
-        dispatch),
+        postAnswer,
+    }),
+    dispatch),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(TaskReview);

--- a/src/views/TaskReview/reducer.js
+++ b/src/views/TaskReview/reducer.js
@@ -1,11 +1,14 @@
 import update from 'immutability-helper';
-import { compact, flatten, get, has, map, findIndex } from 'lodash';
+import {
+    compact, flatten, get, has, map, findIndex,
+} from 'lodash';
 
 import * as type from './actionTypes';
 import {
     GET_ANSWERS_SUCCESS,
     GET_SURVEY_BY_ID_SUCCESS,
-    POST_ANSWER_SUCCESS } from '../../common/actionTypes/surveyActionTypes';
+    POST_ANSWER_SUCCESS,
+} from '../../common/actionTypes/surveyActionTypes';
 
 export const initialState = {
     ui: {
@@ -35,10 +38,15 @@ export default (state = initialState, action) => {
             flatSurvey = compact(flatten(map(action.survey.sections, 'questions')));
         }
         const setActive = flatSurvey.length > 0 ? flatSurvey[0].id : -1;
-        return update(state, { ui: { flagSidebar: { activeId: { $set: setActive },
-            timestamp: { $set: new Date() } },
-            form: { surveyId: { $set: action.surveyId } },
-        } });
+        return update(state, {
+            ui: {
+                flagSidebar: {
+                    activeId: { $set: setActive },
+                    timestamp: { $set: new Date() },
+                },
+                form: { surveyId: { $set: action.surveyId } },
+            },
+        });
     }
     case GET_ANSWERS_SUCCESS:
         return update(state, { ui: { form: { answers: { $set: action.answers } } } });
@@ -46,34 +54,67 @@ export default (state = initialState, action) => {
         const answerIndex = findIndex(state.ui.form.answers,
             answer => answer.questionId === action.questionId);
         if (answerIndex === -1) {
-            return update(state, { ui: { form: { answers: { $push:
+            return update(state, {
+                ui: {
+                    form: {
+                        answers: {
+                            $push:
                 [{ questionId: action.questionId, answer: action.answer }],
-            } } } });
+                        },
+                    },
+                },
+            });
         }
-        return update(state, { ui: { form: { answers: { [answerIndex]: { answer:
-            { $set: action.answer } } } } } });
+        return update(state, {
+            ui: {
+                form: {
+                    answers: {
+                        [answerIndex]: {
+                            answer:
+            { $set: action.answer },
+                        },
+                    },
+                },
+            },
+        });
     }
     case POST_ANSWER_SUCCESS: {
         const answerIndex = findIndex(state.ui.form.answers,
             answer => answer.questionId === action.questionId);
-        const result = has(action, 'meta') ?
-            { questionId: action.questionId, answer: action.answer, meta: action.meta } :
-            { questionId: action.questionId, answer: action.answer };
-        return answerIndex < 0 ?
-            update(state, { ui: { lastSave: { $set: Date.now() },
-                form: { answers: {
-                    $push: [result],
-                } } } }) :
-            update(state, { ui: { lastSave: { $set: Date.now() },
-                form: { answers: { [answerIndex]: { $merge: result } } } } });
+        const result = has(action, 'meta')
+            ? { questionId: action.questionId, answer: action.answer, meta: action.meta }
+            : { questionId: action.questionId, answer: action.answer };
+        return answerIndex < 0
+            ? update(state, {
+                ui: {
+                    lastSave: { $set: Date.now() },
+                    form: {
+                        answers: {
+                            $push: [result],
+                        },
+                    },
+                },
+            })
+            : update(state, {
+                ui: {
+                    lastSave: { $set: Date.now() },
+                    form: { answers: { [answerIndex]: { $merge: result } } },
+                },
+            });
     }
     case type.GET_DISCUSSIONS_SUCCESS:
         return update(state, { ui: { flags: { $set: action.discussions } } });
     case type.UPDATE_QUESTION_DISPLAY:
         return update(state, { ui: { showQuestions: { $set: action.questionArray } } });
     case type.SET_ACTIVE_FLAG:
-        return update(state, { ui: { flagSidebar: { activeId: { $set: action.activeId },
-            timestamp: { $set: action.timestamp } } } });
+        return update(state, {
+            ui: {
+                flagSidebar: {
+                    activeId: { $set: action.activeId },
+                    timestamp: { $set: action.timestamp },
+                },
+            },
+        });
     case type.UPDATE_MARK_RESOLVED:
         return update(state,
             { ui: { flagSidebar: { resolved: { $set: action.resolved } } } });

--- a/src/views/UserDashboard/actions.js
+++ b/src/views/UserDashboard/actions.js
@@ -24,27 +24,25 @@ export function userDashGetMessages() {
             limit: 4,
             received: true,
         })
-        .then((response) => {
-            dispatch(_getMessagesSuccess(response));
-            return response;
-        })
-        .catch((error) => {
-            dispatch(_getMessagesFailure(error));
-        });
+            .then((response) => {
+                dispatch(_getMessagesSuccess(response));
+                return response;
+            })
+            .catch((error) => {
+                dispatch(_getMessagesFailure(error));
+            });
     };
 }
 
 export function getDashboardData(errorMessages, userId) {
-    return dispatch =>
-        (userId !== undefined ?
-            apiService.tasks.getTasksByUser(userId) :
-            apiService.tasks.getSelfTasks()
-        )
+    return dispatch => (userId !== undefined
+        ? apiService.tasks.getTasksByUser(userId)
+        : apiService.tasks.getSelfTasks()
+    )
         .then((taskResp) => {
             dispatch(_getTasksSuccess(taskResp));
             taskResp.forEach(task => dispatch(_getAnswers(task.assessmentId, errorMessages)));
-            uniq(taskResp.map(task => task.surveyId)).forEach(surveyId =>
-                dispatch(_getSurveyById(surveyId, errorMessages)));
+            uniq(taskResp.map(task => task.surveyId)).forEach(surveyId => dispatch(_getSurveyById(surveyId, errorMessages)));
         })
         .catch(() => dispatch(_reportError(errorMessages.FETCH_TASKS)));
 }
@@ -59,28 +57,28 @@ function _reportError(message) {
 function _getAnswers(assessmentId, errorMessages) {
     return (dispatch) => {
         return apiService.surveys.getAnswers(assessmentId)
-        .then((answerResp) => {
-            dispatch(_getAnswersSuccess(answerResp, assessmentId));
-            return answerResp;
-        })
-        .catch((answerErr) => {
-            dispatch(_reportError(errorMessages.ANSWER_REQUEST));
-            throw answerErr;
-        });
+            .then((answerResp) => {
+                dispatch(_getAnswersSuccess(answerResp, assessmentId));
+                return answerResp;
+            })
+            .catch((answerErr) => {
+                dispatch(_reportError(errorMessages.ANSWER_REQUEST));
+                throw answerErr;
+            });
     };
 }
 
 function _getSurveyById(surveyId, errorMessages) {
     return (dispatch) => {
         apiService.surveys.getSurveyById(surveyId)
-        .then((surveyResp) => {
-            dispatch(_getSurveyByIdSuccess(surveyResp));
-            return surveyResp;
-        })
-        .catch((surveyErr) => {
-            dispatch(_reportError(errorMessages.SURVEY_REQUEST));
-            throw surveyErr;
-        });
+            .then((surveyResp) => {
+                dispatch(_getSurveyByIdSuccess(surveyResp));
+                return surveyResp;
+            })
+            .catch((surveyErr) => {
+                dispatch(_reportError(errorMessages.SURVEY_REQUEST));
+                throw surveyErr;
+            });
     };
 }
 

--- a/src/views/UserDashboard/components/UserTaskListEntry.js
+++ b/src/views/UserDashboard/components/UserTaskListEntry.js
@@ -19,12 +19,12 @@ class UserTaskListEntry extends Component {
                     {this.props.subject}
                 </div>
                 <div className='user-task-list-entry__cell user-task-list-entry__cell--task'>
-                    {this.props.late &&
-                    <StatusLabel label={this.props.vocab.COMMON.LATE}
-                                 type={StatusLabelType.BAD}/>}
-                    {!this.props.late && this.props.new &&
-                    <StatusLabel label={this.props.vocab.COMMON.NEW}
-                                 type={StatusLabelType.GOOD} />}
+                    {this.props.late
+                    && <StatusLabel label={this.props.vocab.COMMON.LATE}
+                        type={StatusLabelType.BAD}/>}
+                    {!this.props.late && this.props.new
+                    && <StatusLabel label={this.props.vocab.COMMON.NEW}
+                        type={StatusLabelType.GOOD} />}
                     {this.props.task.title}
                 </div>
                 <div className='user-task-list-entry__cell user-task-list-entry__cell--due'>

--- a/src/views/UserDashboard/components/UserTaskListHeader.js
+++ b/src/views/UserDashboard/components/UserTaskListHeader.js
@@ -1,27 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const UserTaskListHeader = ({ vocab }) =>
-    <div className='user-task-list-header'>
-        <div className='user-task-list-header__title user-task-list-header__title--subject'>
-            {vocab.PROJECT.SUBJECT}
-        </div>
-        <div className='user-task-list-header__title user-task-list-header__title--task'>
-            {vocab.PROJECT.TASK}
-        </div>
-        <div className='user-task-list-header__title user-task-list-header__title--due'>
-            {vocab.PROJECT.DUE}
-        </div>
-        <div className='user-task-list-header__title user-task-list-header__title--survey'>
-            {vocab.PROJECT.SURVEY}
-        </div>
-        <div className='user-task-list-header__title user-task-list-header__title--flags'>
-            {vocab.PROJECT.FLAGS}
-        </div>
-        <div className='user-task-list-header__title user-task-list-header__title--activity'>
-            {vocab.PROJECT.ACTIVITY}
-        </div>
-    </div>;
+const UserTaskListHeader = ({ vocab }) => <div className='user-task-list-header'>
+    <div className='user-task-list-header__title user-task-list-header__title--subject'>
+        {vocab.PROJECT.SUBJECT}
+    </div>
+    <div className='user-task-list-header__title user-task-list-header__title--task'>
+        {vocab.PROJECT.TASK}
+    </div>
+    <div className='user-task-list-header__title user-task-list-header__title--due'>
+        {vocab.PROJECT.DUE}
+    </div>
+    <div className='user-task-list-header__title user-task-list-header__title--survey'>
+        {vocab.PROJECT.SURVEY}
+    </div>
+    <div className='user-task-list-header__title user-task-list-header__title--flags'>
+        {vocab.PROJECT.FLAGS}
+    </div>
+    <div className='user-task-list-header__title user-task-list-header__title--activity'>
+        {vocab.PROJECT.ACTIVITY}
+    </div>
+</div>;
 
 UserTaskListHeader.propTypes = {
     vocab: PropTypes.object.isRequired,

--- a/src/views/UserDashboard/components/index.js
+++ b/src/views/UserDashboard/components/index.js
@@ -50,12 +50,14 @@ class UserDashboard extends Component {
             return true;
         }
     }
+
     searchRow(row) {
         const lowerQuery = this.props.ui.searchQuery.toLowerCase();
-        return row.subject.toLowerCase().includes(lowerQuery) ||
-            row.task.title.toLowerCase().includes(lowerQuery) ||
-            row.survey.toLowerCase().includes(lowerQuery);
+        return row.subject.toLowerCase().includes(lowerQuery)
+            || row.task.title.toLowerCase().includes(lowerQuery)
+            || row.survey.toLowerCase().includes(lowerQuery);
     }
+
     render() {
         return (
             <div className='user-dashboard'>
@@ -73,8 +75,8 @@ class UserDashboard extends Component {
                     <UserTaskListHeader vocab={this.props.vocab} />
                     {
                         this.props.rows.filter(this.filterRow.bind(this))
-                        .filter(this.searchRow.bind(this))
-                        .map(row => <UserTaskListEntry {...row} vocab={this.props.vocab}/>)
+                            .filter(this.searchRow.bind(this))
+                            .map(row => <UserTaskListEntry {...row} vocab={this.props.vocab}/>)
                     }
                 </div>
             </div>
@@ -89,7 +91,8 @@ const mapStateToProps = (state) => {
         .filter(task => get(
             state.projects.data.find(findProject => findProject.id === task.projectId),
             'status',
-            0) === 1)
+            0,
+        ) === 1)
         .map(task => _generateRow(state, task.projectId, task));
     return {
         glance: {
@@ -114,21 +117,19 @@ const mapDispatchToProps = dispatch => ({
 });
 
 const _generateRow = (state, projectId, task) => { // TODO: INBA-439
-    const project = state.projects.data[0].name ?
-        state.projects.data.find(findProject => findProject.id === projectId) :
-        state.projects.data[0];
+    const project = state.projects.data[0].name
+        ? state.projects.data.find(findProject => findProject.id === projectId)
+        : state.projects.data[0];
     const stage = project.stages.find(step => step.id === task.stepId);
-    const subject = project !== undefined ?
-        project.subjects.find(elem => elem.id === task.uoaId) : { name: '' };
-    const answers = state.userdashboard.answers.find(findAnswers =>
-        findAnswers.assessmentId === task.assessmentId);
-    const survey = state.userdashboard.surveys.find(findSurvey =>
-        findSurvey.id === task.surveyId);
+    const subject = project !== undefined
+        ? project.subjects.find(elem => elem.id === task.uoaId) : { name: '' };
+    const answers = state.userdashboard.answers.find(findAnswers => findAnswers.assessmentId === task.assessmentId);
+    const survey = state.userdashboard.surveys.find(findSurvey => findSurvey.id === task.surveyId);
     const surveyLength = survey ? questionListLengthFromSurvey(survey) : 0;
     const answered = get(answers, 'answers.length', 0);
-    const late = !!(task && answers &&
-        TaskStatus.endDateInPast(task) &&
-        !TaskStatus.responsesComplete({ response: answers.answers }, surveyLength));
+    const late = !!(task && answers
+        && TaskStatus.endDateInPast(task)
+        && !TaskStatus.responsesComplete({ response: answers.answers }, surveyLength));
     const complete = task.complete;
     return {
         key: task.id,

--- a/src/views/UserDashboard/reducer.js
+++ b/src/views/UserDashboard/reducer.js
@@ -18,14 +18,19 @@ const initialState = {
 export default (state = initialState, action) => {
     switch (action.type) {
     case actionTypes.USER_DASH_SET_SEARCH_QUERY:
-        return update(state, { ui: {
-            searchQuery: { $set: action.searchQuery },
-        } });
+        return update(state, {
+            ui: {
+                searchQuery: { $set: action.searchQuery },
+            },
+        });
     case actionTypes.USER_DASH_SET_FILTER:
-        return update(state, { ui: {
-            filter: { $apply: filter =>
-                (filter === action.filter ? FILTERS.ALL_TASKS : action.filter) },
-        } });
+        return update(state, {
+            ui: {
+                filter: {
+                    $apply: filter => (filter === action.filter ? FILTERS.ALL_TASKS : action.filter),
+                },
+            },
+        });
     case actionTypes.USER_DASH_GET_MESSAGES_SUCCESS:
         return update(state, {
             messages: { $set: action.messages.messages },
@@ -36,12 +41,12 @@ export default (state = initialState, action) => {
         });
     case actionTypes.USER_DASH_GET_ANSWERS_SUCCESS:
         return update(state, {
-            answers: { $apply: answers => unionBy([action.answers], answers, 'assessmentId'),
-            } });
+            answers: { $apply: answers => unionBy([action.answers], answers, 'assessmentId') },
+        });
     case actionTypes.USER_DASH_GET_SURVEY_BY_ID_SUCCESS:
         return update(state, {
-            surveys: { $apply: surveys => unionBy([action.survey], surveys, 'id'),
-            } });
+            surveys: { $apply: surveys => unionBy([action.survey], surveys, 'id') },
+        });
     default:
         return state;
     }

--- a/src/views/UserProfile/actions.js
+++ b/src/views/UserProfile/actions.js
@@ -20,8 +20,8 @@ export const getTasksForProfile = userId => (dispatch) => {
     dispatch(_getTasksForProfile());
 
     taskService.getTasksByUser(userId)
-    .then(response => dispatch(_getTasksForProfileSuccess(response)))
-    .catch(err => dispatch(_getTasksForProfileFailure(err)));
+        .then(response => dispatch(_getTasksForProfileSuccess(response)))
+        .catch(err => dispatch(_getTasksForProfileFailure(err)));
 };
 
 const _getAllProfileData = () => ({

--- a/src/views/UserProfile/components/AccountTab.js
+++ b/src/views/UserProfile/components/AccountTab.js
@@ -27,15 +27,15 @@ class AccountTab extends Component {
                     {this.props.vocab.PROJECT.ACCOUNT_SINCE}
                     <div className='account-tab__date'>
                         {
-                            this.props.user.lastActive === null ?
-                                this.props.vocab.PROJECT.NOT_ACCEPTED :
-                                Time.renderCommon(this.props.user.created)
+                            this.props.user.lastActive === null
+                                ? this.props.vocab.PROJECT.NOT_ACCEPTED
+                                : Time.renderCommon(this.props.user.created)
                         }
                     </div>
                     <div className='account-tab__button-wrapper'>
                         {
-                            !this.props.user.isActive &&
-                            <button
+                            !this.props.user.isActive
+                            && <button
                                 onClick={this.props.onResendActivation}
                                 className='account-tab__button'>
                                 {this.props.vocab.PROJECT.RESEND_INVITATION}

--- a/src/views/UserProfile/components/PreferenceTab.js
+++ b/src/views/UserProfile/components/PreferenceTab.js
@@ -34,9 +34,9 @@ class PreferenceTab extends Component {
                         component='select'
                         name='isActive'
                         normalize={value => value === constants.status.ACTIVE}
-                        format={value => (value ?
-                            constants.status.ACTIVE :
-                            constants.status.INACTIVE)}>
+                        format={value => (value
+                            ? constants.status.ACTIVE
+                            : constants.status.INACTIVE)}>
                         <option className='preference-tab__input-option'
                             value={constants.status.ACTIVE}>
                             {this.props.vocab.USER.ACTIVE}

--- a/src/views/UserProfile/components/ProfileUserGroupsTab.js
+++ b/src/views/UserProfile/components/ProfileUserGroupsTab.js
@@ -9,7 +9,7 @@ class ProfileUserGroupsTab extends Component {
             .filter(group => group.users.includes(this.props.userId));
         return (
             <UserGroupList {...this.props} groups={groups}
-        columnHeaders={true} />
+                columnHeaders={true} />
         );
     }
 }

--- a/src/views/UserProfile/components/TasksTab.js
+++ b/src/views/UserProfile/components/TasksTab.js
@@ -13,19 +13,18 @@ class TasksTab extends Component {
                         {this.props.vocab.COMMON.SUBJECTS}
                     </div>
                 </div>
-                {this.props.project.stages.map(stage =>
-                    this.props.tasks.some(task => task.userIds.includes(this.props.userId)
-                        && task.stepId === stage.id) &&
-                    <div className='tasks-tab__row' key={stage.id}>
+                {this.props.project.stages.map(stage => this.props.tasks.some(task => task.userIds.includes(this.props.userId)
+                        && task.stepId === stage.id)
+                    && <div className='tasks-tab__row' key={stage.id}>
                         <div className='tasks-tab__cell'>
                             {stage.title}
                         </div>
                         <div className='tasks-tab__cell'>
-                            {this.props.tasks.filter(task =>
-                                task.userIds.includes(this.props.userId) &&
-                                task.stepId === stage.id)
+                            {this.props.tasks.filter(task => task.userIds.includes(this.props.userId)
+                                && task.stepId === stage.id)
                                 .map(task => this.props.project.subjects.find(
-                                    subject => subject.id === task.uoaId).name)
+                                    subject => subject.id === task.uoaId,
+                                ).name)
                                 .join(',')
                             }
                         </div>

--- a/src/views/UserProfile/components/UserProfile.js
+++ b/src/views/UserProfile/components/UserProfile.js
@@ -48,7 +48,7 @@ class UserProfile extends Component {
                             }),
                             this.props.vocab.ERROR);
                     }}/>
-                </Modal>
+            </Modal>
         );
     }
 }

--- a/src/views/UserProfile/components/UserProfileForm.js
+++ b/src/views/UserProfile/components/UserProfileForm.js
@@ -28,8 +28,8 @@ class UserProfileForm extends Component {
                         </FormSection>
                     </Tab>
                     {
-                        this.props.projectId !== undefined &&
-                        <Tab className='user-profile-form__tab'
+                        this.props.projectId !== undefined
+                        && <Tab className='user-profile-form__tab'
                             title={this.props.vocab.PROJECT.USER_GROUPS}>
                             <ProfileUserGroupsTab project={this.props.project}
                                 userId={this.props.userId}
@@ -38,8 +38,8 @@ class UserProfileForm extends Component {
                         </Tab>
                     }
                     {
-                        this.props.projectId !== undefined &&
-                        <Tab className='user-profile-form__tab'
+                        this.props.projectId !== undefined
+                        && <Tab className='user-profile-form__tab'
                             title={this.props.vocab.PROJECT.TASKS}>
                             <TasksTab project={this.props.project}
                                 tasks={this.props.tasks}

--- a/src/views/UserProfile/components/index.js
+++ b/src/views/UserProfile/components/index.js
@@ -18,6 +18,7 @@ class UserProfileContainer extends Component {
         this.props.actions.getAllProfileData(this.props.userId,
             this.props.projectId, this.props.vocab.ERROR);
     }
+
     render() {
         return (
             <UserProfile {...this.props} />
@@ -67,8 +68,7 @@ const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = dispatch => ({
-    onUpdateUser: (userId, user, errorMessages) =>
-        dispatch(updateProfileById(userId, user, errorMessages)),
+    onUpdateUser: (userId, user, errorMessages) => dispatch(updateProfileById(userId, user, errorMessages)),
     onClickToSubmit: () => dispatch(submit('user-profile')),
     actions: bindActionCreators(Object.assign({}, actions,
         { resetPassword, addNewUser }), dispatch),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -13,7 +13,7 @@ module.exports = {
     entry: ['babel-polyfill', './src/index.js'],
     output: {
         path: path.resolve('dist'),
-        filename: 'index_bundle.js',
+        filename: '[name].[contenthash].js',
         publicPath: '/',
     },
     module: {

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
@@ -10,27 +10,27 @@ module.exports = merge(common, {
             {
                 test: /\.(css|scss)$/,
                 use: [
-                   MiniCssExtractPlugin.loader,
+                    MiniCssExtractPlugin.loader,
                     'css-loader',
                     {
-                            loader: 'sass-loader',
-                            options: {
-                                includePaths: ['./node_modules'],
-                            },
+                        loader: 'sass-loader',
+                        options: {
+                            includePaths: ['./node_modules'],
+                        },
                     },
-                ]
+                ],
             },
         ],
     },
     mode: 'production',
     optimization: {
         minimizer: [
-          new UglifyJsPlugin()
+            new UglifyJsPlugin(),
         ],
         splitChunks: {
-            chunks: 'all'
-        }
-      },
+            chunks: 'all',
+        },
+    },
     plugins: [
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify('production'),


### PR DESCRIPTION

#### What does this PR do?
This implements manual tree-shaking on the packages for Indaba -client.  Reducing the download size for the JS to 836KB from 4.7MB.  There are also savings in css, cutting download size by approximately 50%.

This had to be done manually because Grommet 1.X does not support automatic tree shaking see 

https://github.com/grommet/grommet/wiki/Why-Grommet-2.0%3F

section 7

#### Related JIRA tickets:

#### How should this be manually tested?
Run the client
#### Background/Context

#### Screenshots (if appropriate):
