### PR TITLE
INAB-892 / Fix for duplicate users in state.

### DIFF
--- a/src/common/actions/userActions.js
+++ b/src/common/actions/userActions.js
@@ -112,7 +112,10 @@ export function addNewUser(userData, projectId, orgId, toastMessages, errorMessa
                 return userResp;
             })
             .catch((userErr) => {
-                if (userErr.e === 403) {
+                const errorCode = get(userErr, 'body.e');
+                if (errorCode === 409 && requestBody.projectId) {
+                    toast(errorMessages.ALREADY_ASSIGNED);
+                } else if (errorCode === 409 || errorCode === 403) {
                     toast(errorMessages.DUPLICATE);
                 }
                 dispatch(_reportUserError(userErr, errorMessages.USER_REQUEST));

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -54,6 +54,7 @@
     },
     "ERROR": {
         "DUPLICATE": "Attempted to enter a duplicate value. Please enter a unique value instead.",
+        "ALREADY_ASSIGNED": "The user is already assigned to this project.",
         "SERVER_ISSUE": "The server seems to be having some issues or is down. Please try again later.",
         "INVALID_LOGIN": "We weren't able to find your username or password.",
         "FETCH_PROFILE": "Something has gone wrong and we couldn't obtain the user's information. Please try again later.",


### PR DESCRIPTION
**THERE IS A BACKEND CHANGE THAT GOES WITH THIS. CHECK GREYSCALE.** You can find it [here.](https://github.com/amida-tech/greyscale/pull/499)

#### What does this PR do?
There was a bug where duplicate users were being added to the "All Users" and "Project Users" pages. 

#### Related JIRA tickets:

#### How should this be manually tested?
Conditions:
On the "All Users" tab:
- If a user is not in the system at all, he is added. He will appear in the list.
- If a user is in the system but is deleted, he is reactivated and added. He will appear in the list.
- If a user is in the system and isn't deleted, the manager will get a warning about duplicates. No new user will be added to the list (thus no duplicate).

On the "Project Users" tab:
- If a user is not in the system at all, he is added to both system and project. He will appear in the list.
- If a user is deleted, he is reactivated and added to the project. He will appear in the list.
- If a user already is in the project, the manager will get a warning about the user already being assigned to the project. No duplicate will appear.

Be sure to check for the "Add New User" form on the bottom right of the Workflow Matrix.


#### Background/Context

#### Screenshots (if appropriate):
