### PR TITLE
INBA-855 / Disallows the user from setting the survey to draft if project is active

### DIFF
--- a/src/common/actions/taskActions.js
+++ b/src/common/actions/taskActions.js
@@ -120,7 +120,7 @@ export function updateTask(taskId, userIds, endDate, errorMessages) {
         userIds,
         endDate,
     }, identity);
-    
+
     if (requestBody.endDate !== undefined) {
         if (moment.isMoment(requestBody.endDate)) {
             requestBody.endDate = requestBody.endDate.endOf('day');

--- a/src/common/components/Summary/index.js
+++ b/src/common/components/Summary/index.js
@@ -1,10 +1,35 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import IonIcon from 'react-ionicons';
+import { toast } from 'react-toastify';
 
 import StatusCard from './StatusCard';
 
 class Summary extends Component {
+    constructor(props) {
+        super(props);
+        this.onProjectStatusClick = this.onProjectStatusClick.bind(this);
+        this.onSurveyStatusClick = this.onSurveyStatusClick.bind(this);
+    }
+
+    onProjectStatusClick() {
+        if (this.props.onStatusChangeClick) {
+            this.props.onStatusChangeClick('projectstatusmodal');
+        } else {
+            toast(this.props.vocab.PROJECT.WIZARD_INSTRUCTIONS);
+        }
+    }
+
+    onSurveyStatusClick() {
+        if (this.props.project.status) {
+            toast(this.props.vocab.PROJECT.SURVEY_DRAFT_INSTRUCTIONS);
+        } else if (this.props.onStatusChangeClick) {
+            this.props.onStatusChangeClick('surveystatusmodal');
+        } else {
+            toast(this.props.vocab.PROJECT.WIZARD_INSTRUCTIONS);
+        }
+    }
+
     render() {
         return (
             <div className='summary'>
@@ -15,18 +40,14 @@ class Summary extends Component {
                     status={this.props.project.status
                         ? this.props.vocab.PROJECT.STATUS_ACTIVE
                         : this.props.vocab.PROJECT.STATUS_INACTIVE}
-                    onStatusChangeClick={
-                        this.props.onStatusChangeClick
-                        && (() => this.props.onStatusChangeClick('projectstatusmodal'))}
+                    onStatusChangeClick={this.onProjectStatusClick}
                     onEditClick={this.props.onProjectEditClick} />
                 <StatusCard
                     label={this.props.vocab.PROJECT.SURVEY}
                     name={this.props.survey ? this.props.survey.name : ''}
                     actions={this.props.actions}
                     status={this.props.vocab.SURVEY[this.props.survey.status.toUpperCase()]}
-                    onStatusChangeClick={
-                        this.props.onStatusChangeClick
-                        && (() => this.props.onStatusChangeClick('surveystatusmodal'))}
+                    onStatusChangeClick={this.onSurveyStatusClick}
                     onEditClick={this.props.onSurveyEditClick} >
                     <IonIcon
                         icon='ion-ios-paper-outline'

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -313,7 +313,9 @@
         "ANSWERED": "Answered",
         "TASK": "Task",
         "WIZARD_COMPLETE": "Indaba lets Project Managers determine which users participate in a particular stage. Stage dates ensure users access the survey in the correct order, at the correct time.",
-        "NO_PROJECTS": "Please click the Create button to begin a new project."
+        "NO_PROJECTS": "Please click the Create button to begin a new project.",
+        "WIZARD_INSTRUCTIONS": "You can publish a survey or activate a project once you've completed the wizard.",
+        "SURVEY_DRAFT_INSTRUCTIONS": "You cannot make the survey a draft if the project is active. Please deactivate the project."
     },
     "MESSAGES": {
         "TO_REQUIRED": "One or more recipients must be added",


### PR DESCRIPTION
#### What does this PR do?
If the project is active, the user shouldn't be allowed to change the survey to draft. This changes the code such that if they try to, they will get a toast explaining what they need to do instead. 

#### Related JIRA tickets:
INBA-855

#### How should this be manually tested?
1) Go into an active project and try to change the survey to draft. You should see the toast.
2) Inactivate the project and confirm the modal continues to work. Set the survey to draft and confirm that works.
3) Create a new project. Go through the steps until you reach the status. Try click on the status and get a toast explaining that those functions will be available once you've completed the wizard. 

#### Background/Context

#### Screenshots (if appropriate):
