### PR TITLE
Feature/inba-941-better-duplicate-user-toast-text

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -53,7 +53,7 @@
         "INVITED": "An invite has been sent to the user."
     },
     "ERROR": {
-        "DUPLICATE": "Attempted to enter a duplicate value. Please enter a unique value instead.",
+        "DUPLICATE": "You have previously created a user with this email address. Please enter a unique email address for this user.",
         "ALREADY_ASSIGNED": "The user is already assigned to this project.",
         "SERVER_ISSUE": "The server seems to be having some issues or is down. Please try again later.",
         "INVALID_LOGIN": "We weren't able to find your username or password.",


### PR DESCRIPTION
#### What does this PR do?

Changes text for an error log that gets displayed in a toast when a PM user attempts to manually add a user who's email has already been used. 

#### Related JIRA tickets:

INBA-941
https://jira.amida.com/browse/INBA-941

#### How should this be manually tested?

Launch the Indaba Stack. Log in as a PM User. Click on the "All Users" header in the navigation bar. Enter in the information for a user who already exists. The toast for a duplicate user should pop up in the top right hand corner of the screen. 

#### Background/Context

This is a simple change to the en.json file in src/i18n. This error is only called at one point in the code, and thus the text can be changed without the application of a new error message.  

#### Screenshots (if appropriate):

DEVELOP:

![temp](https://user-images.githubusercontent.com/35747608/49821643-ed915f00-fd48-11e8-8d5f-a70928e79860.PNG)

FEATURE/INBA-941:
![capture](https://user-images.githubusercontent.com/35747608/49821720-229db180-fd49-11e8-94dc-c38af268630f.PNG)




