### PR TITLE
[INBA-946] Filter fix.

### DIFF
--- a/src/views/ProjectManagement/components/Workflow/AssigneeContainer/index.js
+++ b/src/views/ProjectManagement/components/Workflow/AssigneeContainer/index.js
@@ -37,6 +37,7 @@ class AssigneeContainer extends Component {
     render() {
         const unassigned = this.props.project.users
             .map(userId => this.props.users.find(userObject => userObject.id === userId))
+            .filter(user => user !== undefined)
             .filter(user => this.searchFilter(renderName(user)))
             .filter(user => this.groupFilter(user));
         const unassignedCards = unassigned.map((unassignee) => {
@@ -45,8 +46,7 @@ class AssigneeContainer extends Component {
                     key={unassignee.id}
                     actions={this.props.actions}
                     project={this.props.project}
-                    vocab={this.props.vocab}
-                >
+                    vocab={this.props.vocab}>
                     {unassignee}
                 </AssigneeCard>
             );


### PR DESCRIPTION
#### What does this PR do?
Before, when you refresh a project management page, it sometimes crashes. This was happening because users weren't arriving before the project data, and the rendering wasn't having it. The (probably) proper fix is to structure the calls by data dependency, but the fix for now is to factor undefined from the filtering.


#### Related JIRA tickets:
INBA-946.

#### How should this be manually tested?
Go to a project with users assigned to it. Refresh the page (hit F5) do this several times and ensure the page loads without crashing and giving console log errors. 

#### Background/Context

#### Screenshots (if appropriate):
