### PR TITLE
Changed out the Grommit Button component in /src/views/profile/compon…

### DIFF
--- a/src/styles/profile/_reset-password-panel.scss
+++ b/src/styles/profile/_reset-password-panel.scss
@@ -9,18 +9,14 @@ $block-class: 'reset-password-panel';
         margin-right: 20%;
 
         &__button {
-            letter-spacing: 0.8px;
-            font-weight: 400;
-            color: #7e848f;
-            background-color: #fff;
-            border-radius: 2px;
+            @extend .alt-button;
+
             border: 2px solid $header-font-color;
-            padding: 2px;
 
             &:hover {
+                color: #fff;
                 background: darken(#4eb276, 10);
                 border-color: darken(#4eb276, 10);
-                color: #fff;
             }
         }
 

--- a/src/views/Profile/components/ResetPasswordPanel.js
+++ b/src/views/Profile/components/ResetPasswordPanel.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Button from 'grommet/components/Button';
 
 class ResetPasswordPanel extends Component {
     render() {
@@ -12,9 +11,10 @@ class ResetPasswordPanel extends Component {
                 <div className='reset-password-panel__instructions'>
                     {this.props.vocab.PROFILE.PASSWORD.INSTRUCTIONS}
                 </div>
-                <Button className='reset-password-panel__button'
-                    secondary={true} label={this.props.vocab.PROFILE.PASSWORD.RESET_PASSWORD}
-                    onClick={() => this.props.actions.resetPassword(this.props.vocab.ERROR)}/>
+                <button className='reset-password-panel__button'
+                        onClick={() => this.props.actions.resetPassword(this.props.vocab.ERROR)}>
+                        <span>{this.props.vocab.PROFILE.PASSWORD.RESET_PASSWORD}</span>
+                </button>
             </div>
         );
     }


### PR DESCRIPTION
…ents/ResetPAsswordPanel into a conventional JSX button, and changed styling in src/styles/profile/reset-password-panel to match the styling of the previous component.

#### What does this PR do?
Updates the code of the Profile Password Reset button to no longer use the Button Grommet component, in preparation for stripping all Grommet out of Indaba-Client.

#### Related JIRA tickets:

INBA-958
https://jira.amida.com/browse/INBA-958

#### How should this be manually tested?
**Before pulling the repo** 
1) Launch Indaba-Client with all it's component back-end.
2) Log into any user account, and click the Profile Icon in the top right to go to the profile page. 
3) Scroll down to the reset password button at the bottom of the profile and note it's behavior.
4) Shut down Indaba-Client
**Now pull this repo** 
5) Relaunch the Indaba-client, log in, navigate to the user profile, and inspect the new password reset button at the bottom of the profile. It should look identical to the screenshot.

#### Screenshots (if appropriate):

![capture](https://user-images.githubusercontent.com/35747608/50609015-7315b400-0e9c-11e9-959a-5277891e993e.PNG)

