### PR TITLE
INBA-954 / removed grommet datepicker, implemented disable

### DIFF
--- a/src/common/components/Dates/MultiDateInput.js
+++ b/src/common/components/Dates/MultiDateInput.js
@@ -5,7 +5,7 @@ import { get } from 'lodash';
 import enhanceWithClickOutside from 'react-click-outside';
 import 'react-dates/initialize';
 import scroller from 'react-scroll/modules/mixins/scroller';
-import { DateRangePicker } from 'react-dates';
+import { DateRangePicker, SingleDatePicker } from 'react-dates';
 
 class MultiDateInput extends Component {
     constructor(props) {
@@ -60,6 +60,7 @@ class MultiDateInput extends Component {
                 focusedInput={this.state.focusedInput}
                 onFocusChange={this.onChangeFocusedInput}
                 hideKeyboardShortcutsPanel={true}
+                displayFormat="MM/DD/YYYY"
             />
         );
     }

--- a/src/common/components/Dates/SingleDateInput.js
+++ b/src/common/components/Dates/SingleDateInput.js
@@ -49,6 +49,7 @@ class SingleDateInput extends Component {
                 numberOfMonths={1}
                 id={this.props.id}
                 hideKeyboardShortcutsPanel={true}
+                disabled={this.props.disable}
             />
         );
     }
@@ -64,6 +65,7 @@ SingleDateInput.propTypes = {
     scrollTarget: PropTypes.string,
     id: PropTypes.string.isRequired,
     onDateChange: PropTypes.func.isRequired,
+    disable: PropTypes.bool,
 };
 
 export default enhanceWithClickOutside(SingleDateInput);

--- a/src/common/components/Dates/SingleDateInput.js
+++ b/src/common/components/Dates/SingleDateInput.js
@@ -45,6 +45,7 @@ class SingleDateInput extends Component {
                 isOutsideRange={this.pastDates}
                 onDateChange={this.onDateChange}
                 focused={this.state.focused}
+                displayFormat="MM/DD/YYYY"
                 onFocusChange={this.onFocusChange}
                 numberOfMonths={1}
                 id={this.props.id}

--- a/src/common/components/Dates/SingleDateInput.js
+++ b/src/common/components/Dates/SingleDateInput.js
@@ -50,7 +50,7 @@ class SingleDateInput extends Component {
                 numberOfMonths={1}
                 id={this.props.id}
                 hideKeyboardShortcutsPanel={true}
-                disabled={this.props.disable}
+                disabled={this.props.disabled}
             />
         );
     }
@@ -66,7 +66,7 @@ SingleDateInput.propTypes = {
     scrollTarget: PropTypes.string,
     id: PropTypes.string.isRequired,
     onDateChange: PropTypes.func.isRequired,
-    disable: PropTypes.bool,
+    disabled: PropTypes.bool,
 };
 
 export default enhanceWithClickOutside(SingleDateInput);

--- a/src/common/components/Dates/SingleDateInput.js
+++ b/src/common/components/Dates/SingleDateInput.js
@@ -6,6 +6,7 @@ import scroller from 'react-scroll/modules/mixins/scroller';
 import moment from 'moment';
 import 'react-dates/initialize';
 import { SingleDatePicker } from 'react-dates';
+import { ANCHOR_LEFT, ANCHOR_RIGHT } from 'react-dates/constants'
 
 class SingleDateInput extends Component {
     constructor(props) {
@@ -13,8 +14,9 @@ class SingleDateInput extends Component {
         this.onFocusChange = this.onFocusChange.bind(this);
         this.onDateChange = this.onDateChange.bind(this);
         this.pastDates = this.pastDates.bind(this);
+        const existingDate = get(this.props, 'value');
         this.state = {
-            date: moment(get(this.props, 'value')),
+            date: existingDate ? moment(existingDate): existingDate,
             focused: null,
         };
     }
@@ -43,9 +45,11 @@ class SingleDateInput extends Component {
             <SingleDatePicker
                 date={this.state.date}
                 isOutsideRange={this.pastDates}
+                placeholder={this.props.placeholder}
                 onDateChange={this.onDateChange}
                 focused={this.state.focused}
                 displayFormat="MM/DD/YYYY"
+                anchorDirection={this.props.align === "right" ? ANCHOR_RIGHT : ANCHOR_LEFT}
                 onFocusChange={this.onFocusChange}
                 numberOfMonths={1}
                 id={this.props.id}
@@ -62,6 +66,8 @@ SingleDateInput.propTypes = {
         PropTypes.string,
         PropTypes.object,
     ]),
+    align: PropTypes.string,
+    placeholder: PropTypes.string,
     containerId: PropTypes.string,
     scrollTarget: PropTypes.string,
     id: PropTypes.string.isRequired,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -46,7 +46,8 @@
         "WELCOME_":"Welcome ",
         "POWERED_BY_AMIDA":"Powered by Amida",
         "VERSION_":"Version ",
-        "STAY_LOGGED_IN":"Stay logged in"
+        "STAY_LOGGED_IN":"Stay logged in",
+        "ENTER_DATE": "Enter Date"
     },
     "TOAST":{
         "EXISTS":"The user is already in the system. If you are on a Project page, we will add them to the project for you.",

--- a/src/styles/common/_react-dates-override.scss
+++ b/src/styles/common/_react-dates-override.scss
@@ -27,7 +27,7 @@
 // is not yet selected. Edits the dates between your mouse and said date
 .CalendarDay__hovered_span:hover,
 .CalendarDay__hovered_span {
-    background: brown;
+    background: #bbb;
 }
 
 .DateInput_input__focused {

--- a/src/views/TaskReview/components/Questions/Date.js
+++ b/src/views/TaskReview/components/Questions/Date.js
@@ -28,21 +28,13 @@ class Date extends Component {
         const currentAnswer = get(this.props, 'answer.dateValue', undefined);
         return (
             <div className='date'>
-                {
-                    (this.props.displayMode
-                    && (
-                        currentAnswer
-                            ? <div className='date__field'>
-                                {currentAnswer}
-                            </div>
-                            : this.props.vocab.SURVEY.NO_DATE_ENTERED
-                    ))
-                    || <SingleDateInput
-                        value={currentAnswer}
-                        onDateChange={this.onDateChange}
-                        id={`date_pick_question${this.props.id}`}
-                        scrollTarget={`question${this.props.questionIndex}`} />
-                }
+                <SingleDateInput
+                    value={currentAnswer}
+                    onDateChange={this.onDateChange}
+                    id={`date_pick_question${this.props.id}`}
+                    scrollTarget={`question${this.props.questionIndex}`}
+                    disabled={this.props.displayMode}
+                />
             </div>
         );
     }

--- a/src/views/TaskReview/components/Questions/Date.js
+++ b/src/views/TaskReview/components/Questions/Date.js
@@ -30,6 +30,7 @@ class Date extends Component {
             <div className='date'>
                 <SingleDateInput
                     value={currentAnswer}
+                    placeholder={this.props.vocab.COMMON.ENTER_DATE}
                     onDateChange={this.onDateChange}
                     id={`date_pick_question${this.props.id}`}
                     scrollTarget={`question${this.props.questionIndex}`}

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -19,7 +19,6 @@ import SingleDatePicker from '../../../../common/components/Dates/SingleDateInpu
 class Questions extends Component {
     render() {
         let QuestionType;
-        let readOnly;
         const value = find(this.props.answers, item => item.questionId === this.props.id);
         const upsertAnswer = newAnswer => this.props.actions.upsertAnswer(
             this.props.assessmentId,

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -163,7 +163,9 @@ class Questions extends Component {
                                     this.props.vocab.ERROR,
                                 )} />
                             <SingleDatePicker className='questions__date-input'
-                                value={get(value, 'meta.publication.date', '')}
+                                value={get(value, 'meta.publication.date')}
+                                align='right'
+                                placeholder={this.props.vocab.COMMON.ENTER_DATE}
                                 disabled={(noValue || this.props.displayMode)}
                                 onDateChange={(event) => {
                                     if (Time.validateTime(event)) {
@@ -186,6 +188,7 @@ class Questions extends Component {
 }
 
 Questions.propTypes = {
+    vocab: PropTypes.object.isRequired,
     type: PropTypes.string.isRequired,
     common: PropTypes.bool,
     text: PropTypes.string.isRequired,

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import {
     find, get, has, merge, omit,
 } from 'lodash';
-import DateTime from 'grommet/components/DateTime';
 import FileForm from './FileForm';
 import FilePane from './FilePane';
 import Bullet from './Bullet';
@@ -15,10 +14,12 @@ import Integer from './Integer';
 import Scale from './Scale';
 import Text from './Text';
 import Time from '../../../../utils/Time';
+import SingleDatePicker from '../../../../common/components/Search';
 
 class Questions extends Component {
     render() {
         let QuestionType;
+        let readOnly;
         const value = find(this.props.answers, item => item.questionId === this.props.id);
         const upsertAnswer = newAnswer => this.props.actions.upsertAnswer(
             this.props.assessmentId,
@@ -162,26 +163,22 @@ class Questions extends Component {
                                         { publication: { author: event.target.value } }),
                                     this.props.vocab.ERROR,
                                 )} />
-                            { (noValue || this.props.displayMode)
-                                ? <input className='questions__date-disabled'
-                                    value={get(value, 'meta.publication.date', 'MM/DD/YYYY')}
-                                    disabled={true} />
-                                : <DateTime className='questions__date-input'
-                                    value={get(value, 'meta.publication.date', '')}
-                                    format='MM/DD/YYYY'
-                                    onChange={(event) => {
-                                        if (Time.validateTime(event)) {
-                                            this.props.actions.upsertAnswer(
-                                                this.props.assessmentId,
-                                                this.props.id,
-                                                value.answer,
-                                                merge(value.meta,
-                                                    { publication: { date: event } }),
-                                                this.props.vocab.ERROR,
-                                            );
-                                        }
-                                    }} />
-                            }
+                            <SingleDatePicker className='questions__date-input'
+                                value={get(value, 'meta.publication.date', '')}
+                                format='MM/DD/YYYY'
+                                disabled={(noValue || this.props.displayMode)}
+                                onDateChange={(event) => {
+                                    if (Time.validateTime(event)) {
+                                        this.props.actions.upsertAnswer(
+                                            this.props.assessmentId,
+                                            this.props.id,
+                                            value.answer,
+                                            merge(value.meta,
+                                                { publication: { date: event } }),
+                                            this.props.vocab.ERROR,
+                                        );
+                                    }
+                                }} />
                         </div>
                     </div>
                 }

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -165,7 +165,6 @@ class Questions extends Component {
                                 )} />
                             <SingleDatePicker className='questions__date-input'
                                 value={get(value, 'meta.publication.date', '')}
-                                format='MM/DD/YYYY'
                                 disabled={(noValue || this.props.displayMode)}
                                 onDateChange={(event) => {
                                     if (Time.validateTime(event)) {

--- a/src/views/TaskReview/components/Questions/index.js
+++ b/src/views/TaskReview/components/Questions/index.js
@@ -14,7 +14,7 @@ import Integer from './Integer';
 import Scale from './Scale';
 import Text from './Text';
 import Time from '../../../../utils/Time';
-import SingleDatePicker from '../../../../common/components/Search';
+import SingleDatePicker from '../../../../common/components/Dates/SingleDateInput';
 
 class Questions extends Component {
     render() {

--- a/src/views/TaskReview/components/TaskDetails.js
+++ b/src/views/TaskReview/components/TaskDetails.js
@@ -67,6 +67,7 @@ class TaskDetails extends Component {
                         { (this.props.profile.roleID === 2 && this.props.task.endDate)
                             ? <SingleDateInput
                                 value={this.props.task.endDate}
+                                placeholder={this.props.vocab.COMMON.ENTER_DATE}
                                 onDateChange={this.onDateChange}
                                 id='task-details-date-pick' />
                             : <div className='task-details__info-box-title'>


### PR DESCRIPTION
#### What does this PR do?
removes grommet uses our implemented singledatepicker  
disable functionality 

#### Related JIRA tickets:
indaba-954

#### How should this be manually tested?
add a question in survey that involves a date. 
fill it out and submit it
see in the admin account has the date. 



#### Background/Context

#### Screenshots (if appropriate):
<img width="778" alt="screen shot 2019-01-04 at 11 15 20 am" src="https://user-images.githubusercontent.com/15223252/50698253-6915c180-1012-11e9-9a98-a0d01c191ee8.png">
<img width="807" alt="screen shot 2019-01-04 at 11 17 32 am" src="https://user-images.githubusercontent.com/15223252/50698256-6adf8500-1012-11e9-90ee-f31e18ff391c.png">
