### PR TITLE
Feature/inba 955 jf menu removal

### DIFF
--- a/src/common/components/Menu.js
+++ b/src/common/components/Menu.js
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import IonIcon from 'react-ionicons';
+
+class Menu extends Component {
+    constructor() {
+        super();
+        this.state = {
+            showMenu: false,
+        }
+        this.openMenu = this.openMenu.bind(this);
+        this.closeMenu = this.closeMenu.bind(this);
+    }
+
+    openMenu(event) {
+        event.preventDefault();
+        this.setState({
+            showMenu: true,
+        });
+    }
+
+    closeMenu() {
+        this.setState({ showMenu: false }, () => {
+            console.log('replication?');
+            document.removeEventListener('click', this.closeMenu);
+        });
+    }
+
+    render() {
+        return (
+            <div className='menu'>
+                <IonIcon icon='ion-ios-plus'
+                    className='menu__icon'
+                    onClick={this.openMenu}/>
+                { this.state.showMenu ? (
+                    <div className='menu__dropdown'>
+                        <span className='menu__insert-label'>
+                            {this.props.vocab.SURVEY.INSERT_INTO}
+                        </span>
+                        <div className='menu__options'>
+                            {this.props.options.map(option => <div className='menu__button'
+                                key={`question-menu${this.props.type}${option.value}`}
+                                onClick={this.props.handleInsert(this.props.type, option.value)}>
+                                {option.label}
+                            </div>)}
+                        </div>
+                    </div>
+                    ) : (null)
+                }
+            </div>
+        )
+    }
+}
+
+Menu.propTypes = {
+    vocab: PropTypes.object.isRequired,
+    options: PropTypes.arrayOf(PropTypes.object).isRequired,
+    type: PropTypes.string.isRequired,
+    handleInsert: PropTypes.func.isRequired,
+};
+
+export default Menu;

--- a/src/common/components/Menu.js
+++ b/src/common/components/Menu.js
@@ -27,7 +27,11 @@ class Menu extends Component {
     }
 
     handleClick(event) {
-        this.props.handleOptionSelection(this.props.type, event.target.value);
+        if (this.props.type) {
+            this.props.handleOptionSelection(this.props.type, event.target.value);
+        } else {
+            this.props.handleOptionSelection(event.target.value);
+        }
     }
 
     render() {
@@ -60,7 +64,7 @@ class Menu extends Component {
 Menu.propTypes = {
     vocab: PropTypes.object.isRequired,
     options: PropTypes.arrayOf(PropTypes.object).isRequired,
-    type: PropTypes.string.isRequired,
+    type: PropTypes.string,
     handleOptionSelection: PropTypes.func.isRequired,
 };
 

--- a/src/common/components/Menu.js
+++ b/src/common/components/Menu.js
@@ -10,39 +10,44 @@ class Menu extends Component {
         }
         this.openMenu = this.openMenu.bind(this);
         this.closeMenu = this.closeMenu.bind(this);
+        this.handleClick = this.handleClick.bind(this);
     }
 
     openMenu(event) {
         event.preventDefault();
-        this.setState({
-            showMenu: true,
+        this.setState({ showMenu: true }, () => {
+            document.addEventListener('click', this.closeMenu);
         });
     }
 
     closeMenu() {
         this.setState({ showMenu: false }, () => {
-            console.log('replication?');
             document.removeEventListener('click', this.closeMenu);
         });
     }
 
+    handleClick(event) {
+        this.props.handleOptionSelection(this.props.type, event.target.value);
+    }
+
     render() {
         return (
-            <div className='menu'>
+            <div className='menu'
+                onClick={this.openMenu}>
                 <IonIcon icon='ion-ios-plus'
-                    className='menu__icon'
-                    onClick={this.openMenu}/>
+                    className='menu__icon'/>
                 { this.state.showMenu ? (
                     <div className='menu__dropdown'>
                         <span className='menu__insert-label'>
                             {this.props.vocab.SURVEY.INSERT_INTO}
                         </span>
                         <div className='menu__options'>
-                            {this.props.options.map(option => <div className='menu__button'
+                            {this.props.options.map(option => <button className='menu__button'
                                 key={`question-menu${this.props.type}${option.value}`}
-                                onClick={this.props.handleInsert(this.props.type, option.value)}>
+                                value={option.value}
+                                onClick={this.handleClick}>
                                 {option.label}
-                            </div>)}
+                            </button>)}
                         </div>
                     </div>
                     ) : (null)
@@ -56,7 +61,7 @@ Menu.propTypes = {
     vocab: PropTypes.object.isRequired,
     options: PropTypes.arrayOf(PropTypes.object).isRequired,
     type: PropTypes.string.isRequired,
-    handleInsert: PropTypes.func.isRequired,
+    handleOptionSelection: PropTypes.func.isRequired,
 };
 
 export default Menu;

--- a/src/styles/common/_menu.scss
+++ b/src/styles/common/_menu.scss
@@ -2,6 +2,8 @@ $block-class: 'menu';
 
 @at-root {
     .#{$block-class} {
+        padding-top: 5px;
+
         &__icon {
             @extend .x-small-icon;
 
@@ -33,13 +35,21 @@ $block-class: 'menu';
         }
 
         &__button {
-            border-bottom: 2px solid $border-color;
-            padding: 0.5em;
-            color: $lead-font-color;
-            font-size: 14px;
+            letter-spacing: 0.3px;
+            font-size: 12px;
+            font-weight: 400;
+            color: $font-inverse-color;
+            background-color: #4eb276;
+            border-radius: 2px;
+            padding: 4px 8px;
 
             &:hover {
-                color: #333;
+                letter-spacing: 0.3px;
+                font-size: 12px;
+                font-weight: 400;
+                background: darken(#4eb276, 10);
+                border-color: darken(#4eb276, 10);
+                text-decoration: none;
             }
         }
     }

--- a/src/styles/common/_menu.scss
+++ b/src/styles/common/_menu.scss
@@ -28,10 +28,7 @@ $block-class: 'menu';
         &__options {
             display: flex;
             flex-direction: column;
-            border-style: solid;
-            border-color: $border-color;
-            border-width: 1px;
-            border-radius: 2px;
+            margin-top: 8px;
         }
 
         &__button {
@@ -42,6 +39,7 @@ $block-class: 'menu';
             background-color: #4eb276;
             border-radius: 2px;
             padding: 4px 8px;
+            margin-bottom: 8px;
 
             &:hover {
                 letter-spacing: 0.3px;

--- a/src/styles/common/_menu.scss
+++ b/src/styles/common/_menu.scss
@@ -1,0 +1,33 @@
+$block-class: 'menu';
+
+@at-root {
+    .#{$block-class} {
+        &__icon {
+            @extend .x-small-icon;
+            fill: $lead-font-color;
+        }
+
+        &__insert-label {
+            padding: 0.5em;
+            font-size: 12px;
+        }
+
+        &__options {
+            border-style: solid;
+            border-color: $border-color;
+            border-width: 1px;
+            border-radius: 2px;
+        }
+
+        &__button {
+            border-bottom: 2px solid $border-color;
+            padding: 0.5em;
+            color: $lead-font-color;
+            font-size: 14px;
+
+            &:hover {
+                color: #333;
+            }
+        }
+    }
+}

--- a/src/styles/common/_menu.scss
+++ b/src/styles/common/_menu.scss
@@ -8,6 +8,16 @@ $block-class: 'menu';
             fill: $lead-font-color;
         }
 
+        &__dropdown {
+            display: block;
+            position: absolute;
+            background-color: #f9f9f9;
+            min-width: 160px;
+            box-shadow: 0 8px 16px 0 rgba(0, 0, 0, 0.2);
+            padding: 6px;
+            z-index: 1;
+        }
+
         &__insert-label {
             padding: 0.5em;
             font-size: 12px;

--- a/src/styles/common/_menu.scss
+++ b/src/styles/common/_menu.scss
@@ -4,6 +4,7 @@ $block-class: 'menu';
     .#{$block-class} {
         &__icon {
             @extend .x-small-icon;
+
             fill: $lead-font-color;
         }
 
@@ -13,6 +14,8 @@ $block-class: 'menu';
         }
 
         &__options {
+            display: flex;
+            flex-direction: column;
             border-style: solid;
             border-color: $border-color;
             border-width: 1px;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -158,3 +158,4 @@
 @import './resetpassword/reset-password-form.scss';
 // Common
 @import './common/react-dates-override.scss';
+@import './common/menu.scss';

--- a/src/styles/surveybuilder/_new-questions.scss
+++ b/src/styles/surveybuilder/_new-questions.scss
@@ -13,33 +13,6 @@ $block-class: 'new-questions';
             align-items: center;
         }
 
-        &__icon {
-            @extend .x-small-icon;
-        }
-
-        &__insert-label {
-            padding: 0.5em;
-            font-size: 12px;
-        }
-
-        &__menu-dropdown {
-            border-style: solid;
-            border-color: $border-color;
-            border-width: 1px;
-            border-radius: 2px;
-        }
-
-        &__menu-button {
-            border-bottom: 2px solid $border-color;
-            padding: 0.5em;
-            color: $lead-font-color;
-            font-size: 14px;
-
-            &:hover {
-                color: #333;
-            }
-        }
-
         &__masked-button {
             background-color: Transparent;
             border: none;

--- a/src/styles/surveybuilder/_new-questions.scss
+++ b/src/styles/surveybuilder/_new-questions.scss
@@ -6,7 +6,7 @@ $block-class: 'new-questions';
             font-size: 14px;
             color: $lead-font-color;
             border-bottom: 1px solid $border-color;
-            padding: 0 1em;
+            padding: 1em;
             display: flex;
             flex-direction: row;
             justify-content: space-between;

--- a/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
+++ b/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
@@ -40,7 +40,7 @@ class NewQuestions extends Component {
                                     vocab={this.props.vocab}
                                     options={this.props.options}
                                     type={type}
-                                    handleInsert={this.handleInsert} />
+                                    handleOptionSelection={this.handleInsert} />
                                 : <button className='new-questions__masked-button'
                                     onClick={() => this.handleInsert(type, this.props.sectionView)}>
                                     <IonIcon icon='ion-ios-plus'

--- a/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
+++ b/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 import { keys } from 'lodash';
-import Menu from 'grommet/components/Menu';
 import IonIcon from 'react-ionicons';
 import PropTypes from 'prop-types';
 
 import { DYNAMIC } from '../../constants';
-
+import Menu from '../../../../common/components/Menu';
 class NewQuestions extends Component {
     constructor(props) {
         super(props);
@@ -37,20 +36,11 @@ class NewQuestions extends Component {
                             key={`question-type${type}`}>
                             {this.props.vocab.SURVEY.QUESTIONS_TYPES[type]}
                             {this.props.sectionView < 0
-                                ? <Menu responsive={true}
-                                    icon={<IonIcon icon='ion-ios-plus'
-                                        className='new-questions__icon'/>}>
-                                    <span className='new-questions__insert-label'>
-                                        {this.props.vocab.SURVEY.INSERT_INTO}
-                                    </span>
-                                    <div className='new-questions__menu-dropdown'>
-                                        {this.props.options.map(option => <div className='new-questions__menu-button'
-                                            key={`question-menu${type}${option.value}`}
-                                            onClick={() => this.handleInsert(type, option.value)}>
-                                            {option.label}
-                                        </div>)}
-                                    </div>
-                                </Menu>
+                                ? <Menu
+                                    vocab={this.props.vocab}
+                                    options={this.props.options}
+                                    type={type}
+                                    handleInsert={this.handleInsert} />
                                 : <button className='new-questions__masked-button'
                                     onClick={() => this.handleInsert(type, this.props.sectionView)}>
                                     <IonIcon icon='ion-ios-plus'


### PR DESCRIPTION
**Do not test until [INBA-952](https://github.com/amida-tech/indaba-client/pull/520) has been merged.**

#### What does this PR do?
Removes the Grommet Menu from the Survey Builder, injecting our own that we can style as we see fit. 

#### Related JIRA tickets:
INBA-952.
INBA-955.

#### How should this be manually tested?
Bring up a survey in build mode and test the functionality of the menu by clicking on the "plus" icon. Also check that the warning about "Box" is gone from the console window. 

#### Background/Context

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/4026454/50672744-e35d2c00-0fa7-11e9-8329-26e293851f0f.png)

