### PR TITLE
INBA-957: Grommet Checkbox Removal

### DIFF
--- a/src/styles/modals/_task-options-form.scss
+++ b/src/styles/modals/_task-options-form.scss
@@ -76,5 +76,40 @@ $block-class:'task-options-form';
 
             margin-top: 40px;
         }
+
+        &__check-container {
+            @extend .divider;
+
+            margin-top: 12px;
+        }
+
+        &__checkbox {
+            @extend .small-icon;
+
+            font-size: 1.75em;
+            margin-right: 10px;
+            margin-bottom: 10px;
+            color: darken(#4eb276, 10);
+
+            &--hidden {
+                display: none;
+                cursor: not-allowed;
+            }
+
+            &:hover {
+                color: #000;
+            }
+
+            &--disabled {
+                @extend .small-icon;
+
+                font-size: 1.75em;
+                margin-right: 10px;
+                margin-bottom: 10px;
+                color: #d9d9d9 !important;
+                cursor: not-allowed;
+                pointer-events: none;
+            }
+        }
     }
 }

--- a/src/styles/profile/_profile-form.scss
+++ b/src/styles/profile/_profile-form.scss
@@ -108,10 +108,27 @@ $block-class: 'profile-form';
             }
         }
 
-        .grommetux-control-icon {
+        &__checkbox {
             @extend .small-icon;
 
-            stroke: $header-font-color;
+            font-size: 1.75em;
+            color: darken(#4eb276, 10);
+
+            &--hidden {
+                display: none;
+                cursor: not-allowed;
+            }
+
+            &--disabled {
+                @extend .small-icon;
+
+                font-size: 1.75em;
+                margin-right: 10px;
+                margin-bottom: 10px;
+                color: #d9d9d9 !important;
+                cursor: not-allowed;
+                pointer-events: none;
+            }
         }
     }
 }

--- a/src/views/Profile/components/ProfileCheckBox.js
+++ b/src/views/Profile/components/ProfileCheckBox.js
@@ -1,16 +1,27 @@
 import React, { Component } from 'react';
-import CheckBox from 'grommet/components/CheckBox';
 
 class ProfileCheckBox extends Component {
     render() {
         return (
-            <CheckBox
-                checked={typeof this.props.input.value === 'boolean'
-                    ? this.props.input.value : false }
-                value={this.props.input.value}
-                onChange={this.props.input.onChange}
-                disabled={true}
-                className='update-profile-form__checkbox' />
+            <div>
+                <input type="checkbox"
+                    id={this.props.input.value}
+                    checked={typeof this.props.input.value === 'boolean'
+                        ? this.props.input.value : false}
+                    value={this.props.input.value}
+                    name={this.props.input.value}
+                    onChange={this.props.input.onChange}
+                    disabled={true}
+                    className='profile-form__checkbox--hidden'
+                />
+                <label
+                    for={this.props.input.value}
+                    className={`
+                            far fa-${this.props.input.checked ? 'check-' : ''}square
+                            profile-form__checkbox--disabled
+                        `}
+                />
+            </div>
         );
     }
 }

--- a/src/views/Profile/components/ProfileCheckBox.js
+++ b/src/views/Profile/components/ProfileCheckBox.js
@@ -3,25 +3,25 @@ import React, { Component } from 'react';
 class ProfileCheckBox extends Component {
     render() {
         return (
-            <div>
-                <input type="checkbox"
-                    id={this.props.input.value}
+            <label
+                htmlFor={this.props.input.name}
+            >
+                <input type={'checkbox'}
+                    id={this.props.input.name}
                     checked={typeof this.props.input.value === 'boolean'
                         ? this.props.input.value : false}
-                    value={this.props.input.value}
-                    name={this.props.input.value}
                     onChange={this.props.input.onChange}
                     disabled={true}
                     className='profile-form__checkbox--hidden'
                 />
-                <label
-                    for={this.props.input.value}
+                <span
+                    id={this.props.input.name}
                     className={`
-                            far fa-${this.props.input.checked ? 'check-' : ''}square
-                            profile-form__checkbox--disabled
-                        `}
+                        far fa-${this.props.input.checked ? 'check-' : ''}square
+                        profile-form__checkbox--disabled
+                    `}
                 />
-            </div>
+            </label>
         );
     }
 }

--- a/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsCheckbox.js
+++ b/src/views/ProjectManagement/components/Modals/TaskOptions/TaskOptionsCheckbox.js
@@ -1,16 +1,29 @@
 import React, { Component } from 'react';
-import CheckBox from 'grommet/components/CheckBox';
 
 class TaskOptionsCheckbox extends Component {
     render() {
         return (
-            <CheckBox
-                checked={!!this.props.input.value}
-                onChange={this.props.input.onChange}
-                className='task-options-form__header'
-                label={this.props.label}
-                disabled={this.props.disabled}
-            />
+            <label
+                htmlFor={this.props.input.name}
+                className='task-options-form__check-container'
+            >
+                <input type={'checkbox'}
+                    id={this.props.input.name}
+                    checked={typeof this.props.input.value === 'boolean'
+                        ? this.props.input.value : false}
+                    onChange={this.props.input.onChange}
+                    disabled={this.props.disabled}
+                    className='task-options-form__checkbox--hidden'
+                />
+                <span
+                    id={this.props.input.name}
+                    className={`
+                            far fa-${this.props.input.checked ? 'check-' : ''}square
+                            task-options-form__checkbox${this.props.disabled ? '--disabled' : ''}
+                        `}
+                />
+                {this.props.label}
+            </label>
         );
     }
 }

--- a/src/views/ProjectManagement/components/Workflow/StageSummary.js
+++ b/src/views/ProjectManagement/components/Workflow/StageSummary.js
@@ -68,7 +68,7 @@ class StageSummary extends Component {
 StageSummary.propTypes = {
     vocab: PropTypes.object.isRequired,
     stage: PropTypes.object.isRequired,
-    fromWizard: PropTypes.boolean,
+    fromWizard: PropTypes.bool,
     userGroups: PropTypes.arrayOf(PropTypes.object).isRequired,
     onClick: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
#### What does this PR do?

Updates the functionality of the checkboxes in the logged in user's profile, as well as the task options modal such that they no longer use Grommet in preparation for removing Grommet from Indaba.

#### Related JIRA tickets:

INBA 957 
https://jira.amida.com/browse/INBA-957

#### How should this be manually tested?

-Pull the repo and start your services. 
-Log into Indaba as a PM user.
-After clicking the profile silhouette in the top right, check to make sure there is a non-functional checkbox in the user's profile under the heading of "Is active?"
-Go to any project that has stages assigned to users. 
-Go to task management, and click on the three elipses to open the task options modal.
-If the task is finished or completed, the checkbox should be greyed out and non-interactive. If the task is unfinished, check to make sure that the checkbox properly modifies state, and can be checked and unchecked.

#### Background/Context

A re-submission of a new version of this branch. Previous version was mistakenly branched off of a branch, leading to code conflicts. 

#### Screenshots (if appropriate):
