### PR TITLE
Bug/inba 979 jf new question styling

### DIFF
--- a/src/common/components/Menu.js
+++ b/src/common/components/Menu.js
@@ -27,7 +27,7 @@ class Menu extends Component {
     }
 
     handleClick(event) {
-        if (this.props.type) {
+        if (this.props.type) { // To allow the handleClick to be agnostic to its use.
             this.props.handleOptionSelection(this.props.type, event.target.value);
         } else {
             this.props.handleOptionSelection(event.target.value);

--- a/src/styles/surveybuilder/_new-questions.scss
+++ b/src/styles/surveybuilder/_new-questions.scss
@@ -16,13 +16,17 @@ $block-class: 'new-questions';
         &__masked-button {
             background-color: Transparent;
             border: none;
-            padding: 1em;
-            margin-left: 2px;
-            margin-bottom: 3.2px;
+            padding: 5px 0 0 0;
             outline: none;
 
             &:active {
                 outline: none;
+            }
+
+            &-icon {
+                @extend .x-small-icon;
+
+                fill: $lead-font-color;
             }
         }
 

--- a/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
+++ b/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
@@ -45,7 +45,7 @@ class NewQuestions extends Component {
                                 : <button className='new-questions__masked-button'
                                     onClick={() => this.handleInsert(type, this.props.sectionView)}>
                                     <IonIcon icon='ion-ios-plus'
-                                        className='new-questions__icon'/>
+                                        className='new-questions__masked-button-icon'/>
                                 </button>}
                         </div>
                     );

--- a/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
+++ b/src/views/SurveyBuilder/components/AddQuestionPanel/NewQuestions.js
@@ -53,7 +53,7 @@ class NewQuestions extends Component {
                 <div className='new-questions__break'>
                     {this.props.vocab.SURVEY.SECTION_BREAK}
                     <button className='new-questions__masked-button'
-                        onClick={() => this.props.actions.insertSection()}>
+                        onClick={this.props.actions.insertSection}>
                         <IonIcon icon='ion-minus'
                             className='new-questions__section-icon'/>
                     </button>


### PR DESCRIPTION
#### What does this PR do?
Fixes an issue where the "Section View" filter was showing two very different styles for the "New Questions" panel. 


#### Related JIRA tickets:
INBA-979

#### How should this be manually tested?
In either the Create Project Wizard or Project Management, go into "Survey." (If Project Management, the survey will have to be unpublished). Look at the styling on the left for the New Questions panel as your basis. Then on the filter that reads "Viewing All Questions", change the value to one of the individual sections. The styling on the left should be the same as it was for "Viewing All Questions."

Then test the functionality. When "Viewing All Questions" clicking on the plus sign should give the user a menu of all sections they could add a question to. And when choosing an individual section in the filter, the question will immediately be added to that particular section (recommend testing with at least two section breaks). 

#### Background/Context

The disparity was happening because of CSS unique to a masked button behind the icon. It has been streamlined to match. 

#### Screenshots (if appropriate):
