### PR TITLE
Removed duplicate font-awesome ref to outdated package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "dotenv-webpack": "^1.5.4",
         "express": "^4.16.2",
         "file-loader": "^2.0.0",
-        "font-awesome": "^4.7.0",
         "form-urlencoded": "^2.0.4",
         "grommet": "^1.10.0",
         "html-webpack-plugin": "^3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4366,7 +4366,7 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "=3.1.0"
 
-font-awesome@^4.3.0, font-awesome@^4.7.0:
+font-awesome@^4.3.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
   integrity sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=


### PR DESCRIPTION
#### What does this PR do?
Removes a duplicate (and outdated by two years) reference to the font-awesome package. 

#### Related JIRA tickets:
https://jira.amida.com/browse/INBA-968

#### How should this be manually tested?
Download the PR 

**DO NOT SKIP THIS STEP**
Run 'yarn' in your indaba-client directory. You will also need to run yarn again once you're out of the branch.

Fire up the Indaba stack. 

1) Log in as any given user. 
2) Check to make sure the mail and user icons in the top right have properly loaded in.
3) Click on either icon. 
4) Make sure that the similar icons in the user profile menu and mail menu work, respectively. 
5) Get to any window that has a search bar. Make sure that the magnifying glass icon appears. 

#### Background/Context
In an attempt to determine whether we were importing Font Awesome through Grommet, I discovered we were not, and were importing it twice. One of these imports was an out-of-date NPM package, and was not being referenced anywhere else in the code, and has since been removed. We are now relying on a CDN import in the /public/index.html to display Font Awesome features.

I'll confer with Kate as well to make sure a ticket to switch us over to using the modern font awesome package is created, as this will cause problems down the line if we attempt to use the CDN during offline mode. 