### PR TITLE
Bug/inba 892 jf duplicate users in state

### DIFF
--- a/src/views/ProjectManagement/components/Users/PMUsersTab/index.js
+++ b/src/views/ProjectManagement/components/Users/PMUsersTab/index.js
@@ -94,7 +94,9 @@ class PMUsersTab extends Component {
                     <Search
                         placeholder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
                         value={this.props.ui.userListSearchQuery}
-                        list={this.props.allUsers.filter(this.searchUser)
+                        list={this.props.allUsers.filter((user) =>
+                            !this.props.project.users.includes(user.id))
+                            .filter(this.searchUser)
                             .map(user => ({
                                 label: renderName(user),
                                 value: user,

--- a/src/views/ProjectManagement/components/Users/PMUsersTab/index.js
+++ b/src/views/ProjectManagement/components/Users/PMUsersTab/index.js
@@ -94,8 +94,7 @@ class PMUsersTab extends Component {
                     <Search
                         placeholder={this.props.vocab.PROJECT.SEARCH_FOR_A_USER}
                         value={this.props.ui.userListSearchQuery}
-                        list={this.props.allUsers.filter((user) =>
-                            !this.props.project.users.includes(user.id))
+                        list={this.props.allUsers.filter(user => !this.props.project.users.includes(user.id))
                             .filter(this.searchUser)
                             .map(user => ({
                                 label: renderName(user),


### PR DESCRIPTION
#### What does this PR do?
Fix for duplicate users in state. This is caused whenever a project manager clicks on the search feature under "Users" for a project, then selects one who is already in the project. This fix just removes the user from the available options, leaving only those who are in the system, but not in the project.

#### Related JIRA tickets:
INBA-892

#### How should this be manually tested?
Go to a project. Check the users that are in the project. Click on the "Add User" dropdown and ensure that you are not presented with any users who are in the current project.

Test by adding another user to the system WITHOUT adding them to the project (done by either going to a _different_ project, or by going to the "All Users" section and inviting the user there). 

Also check by removing a user from a project and checking that they then appear in the dropdown. Then readd, and ensure they disappear from the dropdown.

#### Background/Context

#### Screenshots (if appropriate):
